### PR TITLE
FIX for add/remove Biome throws UnsupportedOperationException

### DIFF
--- a/common/cpw/mods/fml/common/registry/FMLRegistry.java
+++ b/common/cpw/mods/fml/common/registry/FMLRegistry.java
@@ -92,11 +92,6 @@ public class FMLRegistry
         instance.addSpawn(entityName, weightedProb, min, max, spawnList, biomes);
     }
 
-    public static void removeBiome(BiomeGenBase biome)
-    {
-        instance.removeBiome(biome);
-    }
-
     public static void removeSpawn(Class <? extends EntityLiving > entityClass, EnumCreatureType typeOfCreature, BiomeGenBase... biomes)
     {
         instance.removeSpawn(entityClass, typeOfCreature, biomes);

--- a/common/cpw/mods/fml/common/registry/IMinecraftRegistry.java
+++ b/common/cpw/mods/fml/common/registry/IMinecraftRegistry.java
@@ -16,8 +16,6 @@ public interface IMinecraftRegistry
 
     public abstract void removeSpawn(Class <? extends EntityLiving > entityClass, EnumCreatureType typeOfCreature, BiomeGenBase... biomes);
 
-    public abstract void removeBiome(BiomeGenBase biome);
-
     public abstract void addSpawn(String entityName, int weightedProb, int min, int max, EnumCreatureType spawnList, BiomeGenBase... biomes);
 
     public abstract void addSpawn(Class <? extends EntityLiving > entityClass, int weightedProb, int min, int max, EnumCreatureType typeOfCreature, BiomeGenBase... biomes);

--- a/patches/minecraft/net/minecraft/src/WorldType.java.patch
+++ b/patches/minecraft/net/minecraft/src/WorldType.java.patch
@@ -1,15 +1,16 @@
 --- ../src-base/minecraft/net/minecraft/src/WorldType.java	0000-00-00 00:00:00.000000000 -0000
 +++ ../src-work/minecraft/net/minecraft/src/WorldType.java	0000-00-00 00:00:00.000000000 -0000
-@@ -1,5 +1,8 @@
+@@ -1,5 +1,9 @@
  package net.minecraft.src;
  
++import java.util.ArrayList;
 +import java.util.Arrays;
 +import java.util.List;
 +
  public class WorldType
  {
      public static final WorldType[] field_48637_a = new WorldType[16];
-@@ -11,6 +14,8 @@
+@@ -11,6 +15,8 @@
      private boolean field_48633_g;
      private boolean field_48638_h;
  
@@ -18,7 +19,7 @@
      private WorldType(int p_i1080_1_, String p_i1080_2_)
      {
          this(p_i1080_1_, p_i1080_2_, 0);
-@@ -22,6 +27,13 @@
+@@ -22,6 +28,13 @@
          this.field_48632_f = p_i1081_3_;
          this.field_48633_g = true;
          field_48637_a[p_i1081_1_] = this;
@@ -32,7 +33,7 @@
      }
  
      public String func_48628_a()
-@@ -78,4 +90,47 @@
+@@ -78,4 +91,52 @@
  
          return null;
      }
@@ -66,16 +67,21 @@
 +        return biomesForWorldType;
 +    }
 +    
-+    public void addNewBiome(BiomeGenBase biome) {
-+        List<BiomeGenBase> biomes=Arrays.asList(biomesForWorldType);
-+        biomes.add(biome);
-+        biomesForWorldType=biomes.toArray(new BiomeGenBase[0]);
-+    }
++	public void addNewBiome(BiomeGenBase biome) {
++		List<BiomeGenBase> newBiomesForWorld = new ArrayList<BiomeGenBase>();
++		newBiomesForWorld.addAll(Arrays.asList(biomesForWorldType));
++		
++		if (!newBiomesForWorld.contains(biome))
++			newBiomesForWorld.add(biome);
++		biomesForWorldType = newBiomesForWorld.toArray(new BiomeGenBase[0]);
++	}
 +    
 +    public void removeBiome(BiomeGenBase biome) {
-+        List<BiomeGenBase> biomes=Arrays.asList(biomesForWorldType);
-+        biomes.remove(biome);
-+        biomesForWorldType=biomes.toArray(new BiomeGenBase[0]);
++		List<BiomeGenBase> newBiomesForWorld = new ArrayList<BiomeGenBase>();
++		newBiomesForWorld.addAll(Arrays.asList(biomesForWorldType));
++		
++		newBiomesForWorld.remove(biome);
++		biomesForWorldType = newBiomesForWorld.toArray(new BiomeGenBase[0]);
 +    }
 +    
 +    

--- a/patches/minecraft_server/net/minecraft/src/WorldType.java.patch
+++ b/patches/minecraft_server/net/minecraft/src/WorldType.java.patch
@@ -1,15 +1,16 @@
 --- ../src-base/minecraft_server/net/minecraft/src/WorldType.java	0000-00-00 00:00:00.000000000 -0000
 +++ ../src-work/minecraft_server/net/minecraft/src/WorldType.java	0000-00-00 00:00:00.000000000 -0000
-@@ -1,5 +1,8 @@
+@@ -1,5 +1,9 @@
  package net.minecraft.src;
  
++import java.util.ArrayList;
 +import java.util.Arrays;
 +import java.util.List;
 +
  public class WorldType
  {
      public static final WorldType[] field_48459_a = new WorldType[16];
-@@ -11,6 +14,8 @@
+@@ -11,6 +15,8 @@
      private boolean field_48455_g;
      private boolean field_48460_h;
  
@@ -18,7 +19,7 @@
      private WorldType(int p_i1025_1_, String p_i1025_2_)
      {
          this(p_i1025_1_, p_i1025_2_, 0);
-@@ -22,6 +27,15 @@
+@@ -22,6 +28,15 @@
          this.field_48454_f = p_i1026_3_;
          this.field_48455_g = true;
          field_48459_a[p_i1026_1_] = this;
@@ -34,7 +35,7 @@
      }
  
      public String func_48449_a()
-@@ -68,4 +82,14 @@
+@@ -68,4 +83,26 @@
  
          return null;
      }
@@ -44,8 +45,20 @@
 +    }
 +    
 +    public void addNewBiome(BiomeGenBase biome) {
-+        List<BiomeGenBase> biomes=Arrays.asList(biomesForWorldType);
-+        biomes.add(biome);
-+        biomesForWorldType=biomes.toArray(new BiomeGenBase[0]);
++		List<BiomeGenBase> newBiomesForWorld = new ArrayList<BiomeGenBase>();
++		newBiomesForWorld.addAll(Arrays.asList(biomesForWorldType));
++		
++		if (!newBiomesForWorld.contains(biome))
++			newBiomesForWorld.add(biome);
++		biomesForWorldType = newBiomesForWorld.toArray(new BiomeGenBase[0]);
 +    }
++    
++    public void removeBiome(BiomeGenBase biome) {
++		List<BiomeGenBase> newBiomesForWorld = new ArrayList<BiomeGenBase>();
++		newBiomesForWorld.addAll(Arrays.asList(biomesForWorldType));
++		
++		newBiomesForWorld.remove(biome);
++		biomesForWorldType = newBiomesForWorld.toArray(new BiomeGenBase[0]);
++    }
++
  }

--- a/server/cpw/mods/fml/server/FMLServerHandler.java
+++ b/server/cpw/mods/fml/server/FMLServerHandler.java
@@ -550,6 +550,14 @@ public class FMLServerHandler implements IFMLSidedHandler
         WorldType.field_48457_b.addNewBiome(biome);
     }
 
+    /**
+     * @param biome
+     */
+    public void removeBiomeFromDefaultWorldGenerator(BiomeGenBase biome)
+    {
+        WorldType.field_48457_b.removeBiome(biome);
+    }
+
     @Override
     public Object getMinecraftInstance()
     {

--- a/server/net/minecraft/src/ModLoader.java
+++ b/server/net/minecraft/src/ModLoader.java
@@ -591,7 +591,7 @@ public class ModLoader
      */
     public static void removeBiome(BiomeGenBase biome)
     {
-        FMLRegistry.removeBiome(biome);
+        FMLServerHandler.instance().removeBiomeFromDefaultWorldGenerator(biome);
     }
 
     /**

--- a/server/net/minecraft/src/ServerRegistry.java
+++ b/server/net/minecraft/src/ServerRegistry.java
@@ -109,12 +109,6 @@ public class ServerRegistry implements IMinecraftRegistry
     }
 
     @Override
-    public void removeBiome(BiomeGenBase biome)
-    {
-        // NOOP because broken
-    }
-
-    @Override
     public void removeSpawn(Class <? extends EntityLiving > entityClass, EnumCreatureType typeOfCreature, BiomeGenBase... biomes)
     {
         for (BiomeGenBase biome : biomes)


### PR DESCRIPTION
- Arrays.toList() returns a fixed-sized list per java spec. Adding and removing biomes throws UnsupportedOperationException.
- Fixed same on server and added disabled removeBiome functionality. This touched a lot of classes as the nonWorking removeBiome seemed to be lots of places inconsistent with addBiome.
