### PR TITLE
Incorrectly passing the IInventory of the extraction slot instead of the...

### DIFF
--- a/patches/minecraft/net/minecraft/src/SlotCrafting.java.patch
+++ b/patches/minecraft/net/minecraft/src/SlotCrafting.java.patch
@@ -12,7 +12,7 @@
  
      public void func_4103_a(ItemStack p_4103_1_)
      {
-+        FMLClientHandler.instance().onItemCrafted(field_25015_e, p_4103_1_, field_1118_b);
++        FMLClientHandler.instance().onItemCrafted(field_25015_e, p_4103_1_, field_1125_c);
          this.func_48434_c(p_4103_1_);
  
          for (int var2 = 0; var2 < this.field_1125_c.func_469_c(); ++var2)


### PR DESCRIPTION
... crafting matrix, get back to me on why it's doing this instead of the default behavior of ModLoader and Forge.
