### PR TITLE
Make FML logs use system line endings …

### DIFF
--- a/common/cpw/mods/fml/common/FMLLogFormatter.java
+++ b/common/cpw/mods/fml/common/FMLLogFormatter.java
@@ -51,7 +51,7 @@ final class FMLLogFormatter extends Formatter
         }
 
         msg.append(record.getMessage());
-        msg.append('\n');
+        msg.append(System.lineSeparator());
         Throwable thr = record.getThrown();
 
         if (thr != null)


### PR DESCRIPTION
… for consistency with Java stack traces in the logs.
