### PR TITLE
getUniqueBlockModelID and renderWorldBlock

### DIFF
--- a/server/net/minecraft/src/BaseMod.java
+++ b/server/net/minecraft/src/BaseMod.java
@@ -297,7 +297,7 @@ public abstract class BaseMod implements cpw.mods.fml.common.modloader.BaseMod
 
     }
 
-    public boolean renderWorldBlock(Object renderer, IBlockAccess world, int x, int y, int z, Block block, int modelID)
+    public boolean renderWorldBlock(RenderBlocks renderer, IBlockAccess world, int x, int y, int z, Block block, int modelID)
     {
         return false;
 

--- a/server/net/minecraft/src/RenderBlocks.java
+++ b/server/net/minecraft/src/RenderBlocks.java
@@ -1,0 +1,3 @@
+package net.minecraft.src;
+
+public class RenderBlocks {}


### PR DESCRIPTION
First off, I do apoligize if this is the wrong place to ask this kind of feedback. Please do let me know if there is a better place.

While trying to make a Client/Server mod, I needed to render a block myself. The obvious way appears to be to use getUniqueBlockModelID and renderWorldBlock. These functions work fine, and I have a working Client.

For the server, what I do is symlink all files except for the ClientProxy (where the client doesn't have the ServerProxy). This works rather well for everything, but I am stuck here.

getUniqueBlockModelID requires BaseMod as parameter, which can only be the mod itself, which means it is identical for both client and server. But renderWorldBlock on the server is called with Object as first parameter, and on the server it is called with RenderBlocks. In result, I have to make 2 mod_ files. This seems counterproductive with the Proxy idea.

Now of course I might be doing this all wrong, but here is the question / feature request:

can it be made that getUniqueBlockModelID accepts a, say, IRenderWorld class, instead of BaseMod? As far as I could trace, all it does is call back renderWorldBlock, so it seems doable. When I tried this myself, I got kinda stuck at

```
 ModLoaderModContainer mlmc=ModLoaderHelper.registerRenderHelper(mod);
```

which underlines my lack of knowledge in this area. Of course an other (dirty) solution would be to change the client to give Object as first parameter. I did test this solution, and it works perfectly.

tl;dr: I would love a solution where I can hide a RenderWorldBlock in a Proxy, so I don't have to create 2 mod_ files (for server/client), closing the gap between server/client even more (in which you already did an amasing job btw).

Tnx for your time, and great work on FML!
