### PR TITLE
Fix playerLoggedIn for sending packets when a player logs in

### DIFF
--- a/common/cpw/mods/fml/common/network/NetworkRegistry.java
+++ b/common/cpw/mods/fml/common/network/NetworkRegistry.java
@@ -135,11 +135,11 @@ public class NetworkRegistry
 
     void playerLoggedIn(EntityPlayerMP player, NetServerHandler netHandler, NetworkManager manager)
     {
+        generateChannelRegistration(player, netHandler, manager);
         for (IConnectionHandler handler : connectionHandlers)
         {
             handler.playerLoggedIn((Player)player, netHandler, manager);
         }
-        generateChannelRegistration(player, netHandler, manager);
     }
 
     String connectionReceived(NetLoginHandler netHandler, NetworkManager manager)


### PR DESCRIPTION
If you wanted to send a packet in playerLoggedIn it would not send because the channels were registered after all of the connection handlers were called. This simply swaps the order of the handler calling and the channel registration to make sending packets during playerLoggedIn possible.
