### PR TITLE
Shortcut function for addNameForObject()

### DIFF
--- a/common/cpw/mods/fml/common/registry/LanguageRegistry.java
+++ b/common/cpw/mods/fml/common/registry/LanguageRegistry.java
@@ -58,6 +58,11 @@ public class LanguageRegistry
         objectName+=".name";
         addStringLocalization(objectName, lang, name);
     }
+    
+    public static void addName(Object objectToName, String name)
+    {
+        instance().addNameForObject(objectToName, "en_US", name);
+    }
 
     public void loadLanguageTable(Properties languagePack, String lang)
     {


### PR DESCRIPTION
Having that long line of code makes the code a bit ugly... Please make this shortcut function like ModLoader.addName() so I don't need to use ModLoader.addName(). :)
