### PR TITLE
Add Method for Getting an Enum Constant.

### DIFF
--- a/common/cpw/mods/fml/relauncher/ReflectionHelper.java
+++ b/common/cpw/mods/fml/relauncher/ReflectionHelper.java
@@ -14,6 +14,7 @@ package cpw.mods.fml.relauncher;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+
 /**
  * Some reflection helper code.
  *
@@ -178,4 +179,17 @@ public class ReflectionHelper
         }
         throw new UnableToFindMethodException(methodNames, failed);
     }
+    
+    
+	public static <C extends Enum> C getEnumConstant(String name, Class<? extends C> clazz) {
+		for(C constant : clazz.getEnumConstants())
+		{
+			if(constant.name() == name)
+			{
+				return constant;
+			}
+		}
+				
+		return null;
+	}
 }


### PR DESCRIPTION
Add a method to get enum constants by name, this pairs well with the Forge EnumHelper.
