### PR TITLE
Changed addNewArmourRenderingPrefix to addArmor.

### DIFF
--- a/client/cpw/mods/fml/client/registry/RenderingRegistry.java
+++ b/client/cpw/mods/fml/client/registry/RenderingRegistry.java
@@ -38,7 +38,7 @@ public class RenderingRegistry
      * @param armor
      * @return
      */
-    public static int addNewArmourRendererPrefix(String armor)
+    public static int addArmor(String armor)
     {
         RenderPlayer.field_77110_j = ObjectArrays.concat(RenderPlayer.field_77110_j, armor);
         return RenderPlayer.field_77110_j.length - 1;


### PR DESCRIPTION
Javadoc explains enough, I don't think it's necessary for the method to have such a long name.
