### PR TITLE
Update common/cpw/mods/fml/common/versioning/ComparableVersion.java

### DIFF
--- a/common/cpw/mods/fml/common/versioning/ComparableVersion.java
+++ b/common/cpw/mods/fml/common/versioning/ComparableVersion.java
@@ -56,7 +56,7 @@ import java.util.Stack;
  *
  * @see <a href="https://cwiki.apache.org/confluence/display/MAVENOLD/Versioning">"Versioning" on Maven Wiki</a>
  * @author <a href="mailto:kenney@apache.org">Kenney Westerhof</a>
- * @author <a href="mailto:hboutemy@apache.org">Hervé Boutemy</a>
+ * @author <a href="mailto:hboutemy@apache.org">Herve Boutemy</a>
  */
 public class ComparableVersion
     implements Comparable<ComparableVersion>


### PR DESCRIPTION
Is it possible to change ligne 59 (Herve) with not accent on the 'e'
It is because Linux/Oracle Jdk does not like it when compliling Forge/FML
