### PR TITLE
More readable state event logs

### DIFF
--- a/common/cpw/mods/fml/common/LoadController.java
+++ b/common/cpw/mods/fml/common/LoadController.java
@@ -120,9 +120,9 @@ public class LoadController
             activeContainer = mc;
             String modId = mc.getModId();
             stateEvent.applyModContainer(activeContainer());
-            FMLLog.finer("Posting state event %s to mod %s", stateEvent, modId);
+            FMLLog.finer("Posting state event %s to mod %s", stateEvent.getEventType(), modId);
             eventChannels.get(modId).post(stateEvent);
-            FMLLog.finer("State event %s delivered to mod %s", stateEvent, modId);
+            FMLLog.finer("State event %s delivered to mod %s", stateEvent.getEventType(), modId);
             activeContainer = null;
             if (!errors.containsKey(modId))
             {


### PR DESCRIPTION
Should result in cleaner state event logs by not using Object.toString().
