### PR TITLE
Make it possible to pass BiomeGenBase.biomeList to EntityRegister.removeSpawn

### DIFF
--- a/common/cpw/mods/fml/common/registry/EntityRegistry.java
+++ b/common/cpw/mods/fml/common/registry/EntityRegistry.java
@@ -277,6 +277,7 @@ public class EntityRegistry
     {
         for (BiomeGenBase biome : biomes)
         {
+            if (biome == null) continue;
             @SuppressWarnings("unchecked")
             Iterator<SpawnListEntry> spawns = biome.func_76747_a(typeOfCreature).iterator();
 


### PR DESCRIPTION
Currently that will crash minecraft as the Array contains null values.

Changing this would be useful if you want to completely disable spawning of an Entity.

While an an array without the null values can be created easily it would be much cleaner if  FML would allow it.
