### PR TITLE
Add Null check to FMLClientHandler.sendPacket

### DIFF
--- a/client/cpw/mods/fml/client/FMLClientHandler.java
+++ b/client/cpw/mods/fml/client/FMLClientHandler.java
@@ -394,7 +394,10 @@ public class FMLClientHandler implements IFMLSidedHandler
     @Override
     public void sendPacket(Packet packet)
     {
-        client.field_71439_g.field_71174_a.func_72552_c(packet);
+        if(client.field_71439_g != null)
+        {
+            client.field_71439_g.field_71174_a.func_72552_c(packet);'
+        }
     }
 
     @Override


### PR DESCRIPTION
I have a keybind that sends a packet, so I get an NPE if I press it while the player is null, while I can just add my own null check there, it's best to have one here.
