### PR TITLE
Accept .zip coremods

### DIFF
--- a/common/cpw/mods/fml/relauncher/RelaunchLibraryManager.java
+++ b/common/cpw/mods/fml/relauncher/RelaunchLibraryManager.java
@@ -314,7 +314,11 @@ public class RelaunchLibraryManager
             try
             {
                 jar = new JarFile(coreMod);
-                mfAttributes = jar.getManifest().getMainAttributes();
+                if (jar.getManifest() != null) {
+                    mfAttributes = jar.getManifest().getMainAttributes();
+                } else {
+                    mfAttributes = new Attributes();
+                }
             }
             catch (IOException ioe)
             {


### PR DESCRIPTION
This is a tiny patch to accept .zip files in coremods/, to match the behaviour of mods/.  Without it, .zip files are silently ignored, which can be confusing.  By allowing zip files, we also produce useful error messages if they don't contain a proper manifest.

Edit: Okay, it's not quite as tiny now, but FML was dying without a good error message if the manifest file was completely absent.
