### PR TITLE
Set some BiomeDecorator fields public

### DIFF
--- a/common/fml_at.cfg
+++ b/common/fml_at.cfg
@@ -69,3 +69,15 @@ public qu.bN #FD:EntityVillager/field_70958_bB
 public qu.bO #FD:EntityVillager/field_70960_bC
 # GuiButtonMerchant
 public avu #CL:GuiButtonMerchant
+# BiomeDecorator
+public yv.z #FD:BiomeDecorator/field_76832_z #treesPerChunk
+public yv.A #FD:BiomeDecorator/field_76802_A #flowersPerChunk
+public yv.B #FD:BiomeDecorator/field_76803_B #grassPerChunk
+public yv.C #FD:BiomeDecorator/field_76804_C #deadBushPerChunk
+public yv.D #FD:BiomeDecorator/field_76798_D #mushroomsPerChunk
+public yv.E #FD:BiomeDecorator/field_76799_E #reedsPerChunk
+public yv.F #FD:BiomeDecorator/field_76800_F #cactiPerChunk
+public yv.G #FD:BiomeDecorator/field_76801_G #sandPerChunk
+public yv.H #FD:BiomeDecorator/field_76805_H #sandPerChunk2
+public yv.I #FD:BiomeDecorator/field_76806_I #clayPerChunk
+public yv.J #FD:BiomeDecorator/field_76807_J #bigMushroomsPerChunk


### PR DESCRIPTION
This will allow biomes to set features such as  `this.theBiomeDecorator.treesPerChunk = 10`
directly from the biome class instead of each mod creating a workaround.
