### PR TITLE
Dispenser Deprecation

### DIFF
--- a/common/cpw/mods/fml/common/registry/GameRegistry.java
+++ b/common/cpw/mods/fml/common/registry/GameRegistry.java
@@ -83,6 +83,10 @@ public class GameRegistry
         }
     }
 
+    /**
+     * Deprecated in favor for Minecraft's default Diespenser Handler.'
+     */
+    @Deprecated
     public static void registerDispenserHandler(IDispenserHandler handler)
     {
         dispenserHandlers.add(handler);


### PR DESCRIPTION
It seems like the FML dispenser handler isn't working, and vanilla MC has it's own handler so might as well deprecate this one...
