### PR TITLE
Fix MCP installation on OS X

### DIFF
--- a/install/fml.py
+++ b/install/fml.py
@@ -1,4 +1,4 @@
-import os, os.path, sys
+import os, os.path, sys, platform
 import urllib, zipfile
 import shutil, glob, fnmatch
 import subprocess, logging, re, shlex
@@ -691,6 +691,10 @@ def setup_mcp(fml_dir, mcp_dir, dont_gen_conf=True):
     if os.sep == '\\':
         cmd = cmd.replace('\\', '\\\\')
     cmd = shlex.split(cmd)
+
+    osx = platform.system() == 'Darwin'
+    if osx:
+        os.chmod(os.path.join(mcp_dir, 'runtime', 'bin', 'astyle-osx'), 0755)
     
     if windows:
         print 'Patching file %s' % os.path.normpath(runtime)


### PR DESCRIPTION
Without astyle-osx executable, MCP will disable reformatting:

!! reformating disabled due to no astyle or config !!

and all patches will fail to apply: https://gist.github.com/4256281
