### PR TITLE
Small simplification and optimization in tick start/end

### DIFF
--- a/common/cpw/mods/fml/common/FMLCommonHandler.java
+++ b/common/cpw/mods/fml/common/FMLCommonHandler.java
@@ -112,7 +112,7 @@ public class FMLCommonHandler
         for (IScheduledTickHandler ticker : scheduledTicks)
         {
             EnumSet<TickType> ticksToRun = EnumSet.copyOf(Objects.firstNonNull(ticker.ticks(), EnumSet.noneOf(TickType.class)));
-            ticksToRun.removeAll(EnumSet.complementOf(ticks));
+            ticksToRun.retainAll(ticks);
             if (!ticksToRun.isEmpty())
             {
                 ticker.tickStart(ticksToRun, data);
@@ -131,7 +131,7 @@ public class FMLCommonHandler
         for (IScheduledTickHandler ticker : scheduledTicks)
         {
             EnumSet<TickType> ticksToRun = EnumSet.copyOf(Objects.firstNonNull(ticker.ticks(), EnumSet.noneOf(TickType.class)));
-            ticksToRun.removeAll(EnumSet.complementOf(ticks));
+            ticksToRun.retainAll(ticks);
             if (!ticksToRun.isEmpty())
             {
                 ticker.tickEnd(ticksToRun, data);


### PR DESCRIPTION
Change the EnumSet equivalent of "A &= ~ new(~B)" to "A &= B".
This eliminates the need for one temporary object and one static method invocation in a frequently called loop.

Further optimization is possible, but would not necessarily simplify the code, so is not included in this pull request.
