### PR TITLE
Metadata smelting method for GameRegistry

### DIFF
--- a/common/cpw/mods/fml/common/registry/GameRegistry.java
+++ b/common/cpw/mods/fml/common/registry/GameRegistry.java
@@ -267,6 +267,11 @@ public class GameRegistry
     {
         FurnaceRecipes.func_77602_a().func_77600_a(input, output, xp);
     }
+    
+    public static void addSmelting(int input, int metadata, ItemStack output, float xp)
+    {
+        FurnaceRecipes.func_77602_a().func_77600_a(input, metadata, output, xp);
+    }
 
     public static void registerTileEntity(Class<? extends TileEntity> tileEntityClass, String id)
     {


### PR DESCRIPTION
Added a new version of the addSmelting method that takes metadata into account. This way, you don't have to call FurnaceRecipes to add a metadata sensitive smelting recipe.
