### PR TITLE
FMLLogFormatter: dynamic log level name

### DIFF
--- a/common/cpw/mods/fml/relauncher/FMLLogFormatter.java
+++ b/common/cpw/mods/fml/relauncher/FMLLogFormatter.java
@@ -22,33 +22,19 @@ final class FMLLogFormatter extends Formatter
         msg.append(this.dateFormat.format(Long.valueOf(record.getMillis())));
         Level lvl = record.getLevel();
 
-        if (lvl == Level.FINEST)
+        String name = lvl.getLocalizedName();
+        if ( name == null )
         {
-            msg.append(" [FINEST] ");
+            name = lvl.getName();        	
         }
-        else if (lvl == Level.FINER)
+
+        if ( ( name != null ) && ( name.length() > 0 ) )
         {
-            msg.append(" [FINER] ");
+            msg.append(" [" + name + "] ");
         }
-        else if (lvl == Level.FINE)
+        else
         {
-            msg.append(" [FINE] ");
-        }
-        else if (lvl == Level.INFO)
-        {
-            msg.append(" [INFO] ");
-        }
-        else if (lvl == Level.WARNING)
-        {
-            msg.append(" [WARNING] ");
-        }
-        else if (lvl == Level.SEVERE)
-        {
-            msg.append(" [SEVERE] ");
-        }
-        else if (lvl == Level.SEVERE)
-        {
-            msg.append(" [" + lvl.getLocalizedName() + "] ");
+            msg.append(" ");
         }
 
         if (record.getLoggerName() != null)


### PR DESCRIPTION
FMLLogFormatter now uses getLocalizedName or getName for log level name instead of a series of if/else if/else statements.

This allows mods to add their own custom log level classes have have them display the names of the levels in the console.  Also fixes a missing space between the timestamp and the logger name when no level name is printed.

Changes to be committed:
    modified:   common/cpw/mods/fml/relauncher/FMLLogFormatter.java
