### PR TITLE
Update client/cpw/mods/fml/client/registry/RenderingRegistry.java

### DIFF
--- a/client/cpw/mods/fml/client/registry/RenderingRegistry.java
+++ b/client/cpw/mods/fml/client/registry/RenderingRegistry.java
@@ -24,7 +24,7 @@ public class RenderingRegistry
 {
     private static final RenderingRegistry INSTANCE = new RenderingRegistry();
 
-    private int nextRenderId = 36;
+    private int nextRenderId = 39;
 
     private Map<Integer, ISimpleBlockRenderingHandler> blockRenderers = Maps.newHashMap();
 


### PR DESCRIPTION
Updated nextRenderId to 39, so FML doesn't attempt to assign the ID of the hopper renderer to a block.
