### PR TITLE
EntityAnimal does not use the experienceValue of its Parent Class (yet)

### DIFF
--- a/patches/minecraft/net/minecraft/entity/passive/EntityAnimal.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntityAnimal.java.patch
@@ -6,7 +6,10 @@
 32,33d27
 <         this.experienceValue = 1;
 <         this.experienceValueAddition = 3;
-324c318
-<    	 return this.experienceValue + this.worldObj.rand.nextInt(this.experienceValueAddition);
+324,327c318
+< 		 if(this.experienceValueAddition<=0)
+< 			return this.experienceValue;
+< 		 else
+<    	 	return this.experienceValue + this.worldObj.rand.nextInt(this.experienceValueAddition);
 ---
 >         return 1 + this.worldObj.rand.nextInt(3);


### PR DESCRIPTION
I Also added a new variable experienceValueAddition that will mark the
Maximum random Value added to the experienceValue. You may set both
values to 0 to avoid XP Drops by the Animals.

The reason is that I want to be able to change the XP Drop Values to 0 (and also allow other values).
