### PR TITLE
Deprecate seemingly useless annotations.

### DIFF
--- a/common/cpw/mods/fml/common/Mod.java
+++ b/common/cpw/mods/fml/common/Mod.java
@@ -226,6 +226,7 @@ public @interface Mod
      */
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.FIELD)
+    @Deprecated
     public @interface Block {
         /**
          * The block's name
@@ -243,6 +244,7 @@ public @interface Mod
      */
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.FIELD)
+    @Deprecated
     public @interface Item {
         /**
          * The name of the item


### PR DESCRIPTION
I was looking through the code, and noted nothing seemed to be being done with @Mod.Item/Block and decided to deprecate them.
