### PR TITLE
Fix NPE when the client is in demo mode

### DIFF
--- a/client/cpw/mods/fml/client/FMLClientHandler.java
+++ b/client/cpw/mods/fml/client/FMLClientHandler.java
@@ -130,6 +130,7 @@ public class FMLClientHandler implements IFMLSidedHandler
      */
     public void beginMinecraftLoading(Minecraft minecraft)
     {
+        client = minecraft;
         if (minecraft.func_71355_q())
         {
             FMLLog.severe("DEMO MODE DETECTED, FML will not work. Finishing now.");
@@ -138,7 +139,6 @@ public class FMLClientHandler implements IFMLSidedHandler
         }
 
         loading = true;
-        client = minecraft;
         ObfuscationReflectionHelper.detectObfuscation(World.class);
         TextureFXManager.instance().setClient(client);
         FMLCommonHandler.instance().beginLoading(this);


### PR DESCRIPTION
When the Client is in demo mode FML will try to crash with a "nice" error report saying it won't run in demo mode. That fails because of a NPE.
