### PR TITLE
Console log thread should be a daemon thread.

### DIFF
--- a/common/cpw/mods/fml/relauncher/FMLRelaunchLog.java
+++ b/common/cpw/mods/fml/relauncher/FMLRelaunchLog.java
@@ -151,6 +151,7 @@ public class FMLRelaunchLog
         log.myLog.setLevel(Level.ALL);
         log.myLog.setUseParentHandlers(false);
         consoleLogThread = new Thread(new ConsoleLogThread());
+        consoleLogThread.setDaemon(true);
         consoleLogThread.start();
         formatter = new FMLLogFormatter();
         try


### PR DESCRIPTION
Otherwise it can keep the whole JVM running if Minecraft/FML crashes very early (while loading coremods for example)
