### PR TITLE
read all the bytes in 1 hit.

### DIFF
--- a/common/cpw/mods/fml/common/asm/transformers/MCPMerger.java
+++ b/common/cpw/mods/fml/common/asm/transformers/MCPMerger.java
@@ -352,19 +352,9 @@ public class MCPMerger
     }
     private static byte[] readFully(InputStream stream) throws IOException
     {
-        byte[] data = new byte[4096];
-        ByteArrayOutputStream entryBuffer = new ByteArrayOutputStream();
-        int len;
-        do
-        {
-            len = stream.read(data);
-            if (len > 0)
-            {
-                entryBuffer.write(data, 0, len);
-            }
-        } while (len != -1);
-
-        return entryBuffer.toByteArray();
+    	byte[] arr = new byte[stream.available()];
+    	stream.read(arr, 0, stream.available());
+        return arr;
     }
     private static class ClassInfo
     {

--- a/common/cpw/mods/fml/relauncher/RelaunchClassLoader.java
+++ b/common/cpw/mods/fml/relauncher/RelaunchClassLoader.java
@@ -247,14 +247,9 @@ public class RelaunchClassLoader extends URLClassLoader
     {
         try
         {
-            ByteArrayOutputStream bos = new ByteArrayOutputStream(stream.available());
-            int r;
-            while ((r = stream.read()) != -1)
-            {
-                bos.write(r);
-            }
-
-            return bos.toByteArray();
+        	byte[] arr = new byte[stream.available()];
+        	stream.read(arr, 0, stream.available());
+            return arr;
         }
         catch (Throwable t)
         {


### PR DESCRIPTION
also, no need to ping-pong through a 1 or 4096 byte buffer, before copying it again.

addresses #190 , following up on #190#issuecomment-14007916
