### PR TITLE
Fixed IndexOutOfBoundsException.

### DIFF
--- a/client/cpw/mods/fml/client/GuiModList.java
+++ b/client/cpw/mods/fml/client/GuiModList.java
@@ -120,7 +120,7 @@ public class GuiModList extends GuiScreen
                 if (!selectedMod.getMetadata().logoFile.isEmpty())
                 {
                     List<Texture> texList = TextureManager.func_94267_b().func_94266_e(selectedMod.getMetadata().logoFile);
-                    if (texList != null)// Potentially could not find the texture
+                    if (texList != null && texList.size() != 0)// Potentially could not find the texture
                     {
                         Texture texture = texList.get(0);
                         texture.func_94277_a(0);


### PR DESCRIPTION
 Fixed IndexOutOfBoundsException due to texList being a zero sized List rather then just null. TextureManager will initialize the arraylist used to return the texture to drawScreen() but will not add anything to it due to problems with textures not being animated nor being a 1:1 ratio.
