### PR TITLE
Fix install.py --mcp-dir option

### DIFF
--- a/install/install.py
+++ b/install/install.py
@@ -17,7 +17,7 @@ def fml_main(fml_dir, mcp_dir, dont_gen_conf=True, disable_patches=False, disabl
     
 if __name__ == '__main__':
     parser = OptionParser()
-    parser.add_option('-m', '--mcp-dir',   action='store_true', dest='mcp_dir',       help='Path to download/extract MCP to',         default=None )
+    parser.add_option('-m', '--mcp-dir',   action='store',      dest='mcp_dir',       help='Path to download/extract MCP to',         default=None )
     parser.add_option('-p', '--no-patch',  action="store_true", dest='no_patch',      help='Disable application of FML patches',      default=False)
     parser.add_option('-a', '--no-access', action="store_true", dest='no_access',     help='Disable access transformers',             default=False)
     parser.add_option('-s', '--server',    action="store_true", dest='enable_server', help='Enable decompilation of server',          default=False)


### PR DESCRIPTION
The --mcp-dir command-line option to FML install.py always fails with:

 $ py install.py --mcp-dir
Traceback (most recent call last):
  File "install.py", line 33, in <module>
    mcp_dir = os.path.abspath(options.mcp_dir)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/posixpath.py", line 343, in abspath
    if not isabs(path):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/posixpath.py", line 53, in isabs
    return s.startswith('/')
AttributeError: 'bool' object has no attribute 'startswith'

This PR changes the argument to 'store' instead of 'store_true', allowing the custom MCP dir to be passed without error.
