### PR TITLE
Fixed FMLRelaunchLog's Newline Handling

### DIFF
--- a/common/cpw/mods/fml/relauncher/FMLRelaunchLog.java
+++ b/common/cpw/mods/fml/relauncher/FMLRelaunchLog.java
@@ -113,7 +113,7 @@ public class FMLRelaunchLog
                 // Are we longer than just the line separator?
                 int lastIdx = -1;
                 int idx = currentMessage.indexOf("\n",lastIdx+1);
-                while (idx > 0)
+                while (idx >= 0)
                 {
                     log.log(Level.INFO, currentMessage.substring(lastIdx+1,idx));
                     lastIdx = idx;


### PR DESCRIPTION
`System.out.println("\n")` causes `currentMessage` to start with a newline character, which means `idx` will always be 0 from then on. Therefore if `idx` is 0 messages must still be logged, otherwise no more messages sent to stdout will be logged and they will just accumulate in `currentMessage`. This is a real issue because the first thing that is logged when the sound manager is set up is a newline, and so currently no messages logged by mods are displayed.

Commit which introduced this bug: https://github.com/MinecraftForge/FML/commit/5cc90f060caace93c0bf041d3cc37208f425f623
