### PR TITLE
shouldRender3DInInventory should have a modelId argument

### DIFF
--- a/client/cpw/mods/fml/client/registry/ISimpleBlockRenderingHandler.java
+++ b/client/cpw/mods/fml/client/registry/ISimpleBlockRenderingHandler.java
@@ -22,7 +22,7 @@ public interface ISimpleBlockRenderingHandler
 
     public abstract boolean renderWorldBlock(IBlockAccess world, int x, int y, int z, Block block, int modelId, RenderBlocks renderer);
 
-    public abstract boolean shouldRender3DInInventory(int modelId);
+    public abstract boolean shouldRender3DInInventory();
 
     public abstract int getRenderId();
 }

--- a/client/cpw/mods/fml/client/registry/RenderingRegistry.java
+++ b/client/cpw/mods/fml/client/registry/RenderingRegistry.java
@@ -38,6 +38,8 @@ public class RenderingRegistry
     private int nextRenderId = 40;
 
     private Map<Integer, ISimpleBlockRenderingHandler> blockRenderers = Maps.newHashMap();
+	
+	private Map<Integer, Boolean> render3dInInventory = Maps.newHashMap();
 
     private List<EntityRendererInfo> entityRenderers = Lists.newArrayList();
 
@@ -86,6 +88,22 @@ public class RenderingRegistry
     public static void registerBlockHandler(int renderId, ISimpleBlockRenderingHandler handler)
     {
         instance().blockRenderers.put(renderId, handler);
+    }
+	
+	/**
+     * Register the simple block rendering handler
+     * This version will not call getRenderId on the passed in handler, instead using the supplied ID, so you
+     * can easily re-use the same rendering handler for multiple IDs, and it will set if the renderId given
+	 * should be rendered 3D in the inventory
+     *
+     * @param renderId
+     * @param handler
+	 * @param render3dInInventory
+     */
+    public static void registerBlockHandler(int renderId, ISimpleBlockRenderingHandler handler, boolean render3dInInventory)
+    {
+        instance().blockRenderers.put(renderId, handler);
+		instance().render3dInInventory.put(renderId, render3dInInventory);
     }
     /**
      * Get the next available renderId from the block render ID list
@@ -163,7 +181,7 @@ public class RenderingRegistry
     public boolean renderItemAsFull3DBlock(int modelId)
     {
         ISimpleBlockRenderingHandler bri = blockRenderers.get(modelId);
-        return bri != null && bri.shouldRender3DInInventory(modelId);
+        return bri != null && (bri.shouldRender3DInInventory() || (render3dInInventory.containsKey(modelId) && render3dInInventory.get(modelId)));
     }
 
     public void loadEntityRenderers(Map<Class<? extends Entity>, Render> rendererMap)


### PR DESCRIPTION
ISBRH can be registered to respond to different modelIds, so that just one ISBRH would be needed for each mod.

So, why not let people decide depending on the modelId if the block should render 3d in the inventory, without having to make two ISBRHs, one for 3D inventory, and the other not?
