### PR TITLE
Allow development time deobfuscation of mods to an MCP target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /mods
 /fmlbuild.properties
 /fmlversion.properties
+/mod_deobf.srg
 /difflist.txt
 /target
 fmlbranding.properties

--- a/common/cpw/mods/fml/common/asm/FMLSanityChecker.java
+++ b/common/cpw/mods/fml/common/asm/FMLSanityChecker.java
@@ -138,7 +138,7 @@ public class FMLSanityChecker implements IFMLCallHook
     public void injectData(Map<String, Object> data)
     {
         cl = (RelaunchClassLoader) data.get("classLoader");
-        FMLDeobfuscatingRemapper.INSTANCE.setup((File)data.get("mcLocation"), cl, (String) data.get("deobfuscationFileName"));
+        FMLDeobfuscatingRemapper.INSTANCE.setup((File)data.get("mcLocation"), cl, (String) data.get("deobfuscationFileName"), (Boolean)data.get("runtimeDeobfuscationEnabled"));
     }
 
 }

--- a/common/cpw/mods/fml/relauncher/RelaunchClassLoader.java
+++ b/common/cpw/mods/fml/relauncher/RelaunchClassLoader.java
@@ -115,13 +115,13 @@ public class RelaunchClassLoader extends URLClassLoader
         }
     }
 
-    public void registerTransformer(String transformerClassName)
+    public void registerTransformer(String transformerClassName, boolean setRenameTransformer)
     {
         try
         {
             IClassTransformer transformer = (IClassTransformer) loadClass(transformerClassName).newInstance();
             transformers.add(transformer);
-            if (transformer instanceof IClassNameTransformer && renameTransformer == null)
+            if (setRenameTransformer && transformer instanceof IClassNameTransformer && renameTransformer == null)
             {
                 renameTransformer = (IClassNameTransformer) transformer;
             }


### PR DESCRIPTION
This PR adds property `fml.forcedDeobfuscationPrefixes`, which allows users to force classes to be deobfuscated, even when using unobfuscated environment. When using unobfuscated code both raw and srg names are converted to versions used in rest of codebase.

Option can be used to easily test interactions with closed source mods without reobfuscation.
