### PR TITLE
Add srgname to registerTileEntityWithAlternatives

### DIFF
--- a/common/cpw/mods/fml/common/registry/GameRegistry.java
+++ b/common/cpw/mods/fml/common/registry/GameRegistry.java
@@ -275,7 +275,7 @@ public class GameRegistry
     public static void registerTileEntityWithAlternatives(Class<? extends TileEntity> tileEntityClass, String id, String... alternatives)
     {
         TileEntity.func_70306_a(tileEntityClass, id);
-        Map<String,Class> teMappings = ObfuscationReflectionHelper.getPrivateValue(TileEntity.class, null, "field_70326_a", "a");
+        Map<String,Class> teMappings = ObfuscationReflectionHelper.getPrivateValue(TileEntity.class, null, "field_" + "70326_a", "field_70326_a", "a");
         for (String s: alternatives)
         {
             if (!teMappings.containsKey(s))


### PR DESCRIPTION
> Map<String,Class> teMappings = ObfuscationReflectionHelper.getPrivateValue(TileEntity.class, null, "field_70326_a", "a");

is replaced during MCP updatenames (in MinecraftForge/mcp/src_work/minecraftcpw/mods/fml/common/registry/GameRegistry.java) with:

> Map<String,Class> teMappings = ObfuscationReflectionHelper.getPrivateValue(TileEntity.class, null, "nameToClassMap", "a");

At runtime, only the the obfuscated version-dependent "a" name is found. Works fine as long as the obfuscated name remains the same, but loses the version-independence benefit of srgnames. 

This PR adds the srgname split up so it won't be replaced by updatenames (same technique used in cpw/mods/fml/relauncher/FMLRelauncher.java), for version-independence (and keeping the original name so all names are tried: srgname, csvname, obfuscated): 

> Map<String,Class> teMappings = ObfuscationReflectionHelper.getPrivateValue(TileEntity.class, null, "field_" + "70326_a", "field_70326_a", "a");
