### PR TITLE
Suggested fix for issue 221

### DIFF
--- a/common/cpw/mods/fml/common/registry/GameRegistry.java
+++ b/common/cpw/mods/fml/common/registry/GameRegistry.java
@@ -221,7 +221,7 @@ public class GameRegistry
             }
             catch (NoSuchMethodException e)
             {
-                itemCtor = itemclass.getConstructor(int.class, Block.class);
+                itemCtor = itemclass.getConstructor(int.class, net.minecraft.block.Block.class);
                 i = itemCtor.newInstance(blockItemId, block);
             }
             GameRegistry.registerItem(i,name, modId);


### PR DESCRIPTION
Fixing the GameRegistry. Now it is possible to register a Block with a BlockItem using following code:

```
MyBlock myBlock = new MyBlock();
GameRegistry.registerBlock(myBlock, MyBlockItem.class, "myBlock");
```

where MyBlockItem class has one constructor with signature:

```
public MyBlockItem(int id, Block block)
```
