### PR TITLE
Fix exclusion of coremods when examining mod candidates.

### DIFF
--- a/common/cpw/mods/fml/common/discovery/JarDiscoverer.java
+++ b/common/cpw/mods/fml/common/discovery/JarDiscoverer.java
@@ -40,7 +40,7 @@ public class JarDiscoverer implements ITypeDiscoverer
         {
             jar = new JarFile(candidate.getModContainer());
 
-            if (jar.getManifest()!=null && jar.getManifest().getMainAttributes().getValue("FMLCorePlugin") != null)
+            if (!candidate.isClasspath() && jar.getManifest()!=null && jar.getManifest().getMainAttributes().getValue("FMLCorePlugin") != null)
             {
                 FMLLog.finest("Ignoring coremod %s", candidate.getModContainer());
                 return foundMods;


### PR DESCRIPTION
Use getValue() instead of get() to actually look up the FMLCorePlugin entry in the attributes map.
