### PR TITLE
Skip ModCandidates already considered in findModDirMods

### DIFF
--- a/common/cpw/mods/fml/common/discovery/JarDiscoverer.java
+++ b/common/cpw/mods/fml/common/discovery/JarDiscoverer.java
@@ -40,11 +40,6 @@ public class JarDiscoverer implements ITypeDiscoverer
         {
             jar = new JarFile(candidate.getModContainer());
 
-            if (jar.getManifest()!=null && jar.getManifest().getMainAttributes().get("FMLCorePlugin") != null)
-            {
-                FMLLog.finest("Ignoring coremod %s", candidate.getModContainer());
-                return foundMods;
-            }
             ZipEntry modInfo = jar.getEntry("mcmod.info");
             MetadataCollection mc = null;
             if (modInfo != null)

--- a/common/cpw/mods/fml/common/discovery/ModDiscoverer.java
+++ b/common/cpw/mods/fml/common/discovery/ModDiscoverer.java
@@ -76,9 +76,19 @@ public class ModDiscoverer
 
     public void findModDirMods(File modsDir)
     {
-        File[] modList = modsDir.listFiles();
+        List<File> modList = new ArrayList<File>(Arrays.asList(modsDir.listFiles()));
+
+        // Skip files already added as candidates
+        for (ModCandidate candidate : candidates)
+        {
+            if (modList.remove(candidate.getModContainer()))
+            {
+                FMLLog.fine("Skipping already added candidate %s", candidate.getModContainer().getName());
+            }
+        }
+
         // Sort the files into alphabetical order first
-        Arrays.sort(modList);
+        Collections.sort(modList);
 
         for (File modFile : modList)
         {


### PR DESCRIPTION
Fixes issues with the coremods/mods folder merger causing coremods to be considered 'non-mod' files and added to the classpath.
Additionally fixes issues with the folder merge causing duplicate mods errors involving coremods and normal mods sharing a jar file.

This is an alternate solution to the same issue as #246, but it also fixes the issue mentioned there that that PR doesn't fix, that coremods (either skipped by that patch, or without any @Mod classes originally) are detected as non-mod files and re-added to the classpath.
