### PR TITLE
Update ModDiscoverer to read mods from Symbolic Links

### DIFF
--- a/common/cpw/mods/fml/common/discovery/ModDiscoverer.java
+++ b/common/cpw/mods/fml/common/discovery/ModDiscoverer.java
@@ -46,7 +46,7 @@ public class ModDiscoverer
     {
         List<String> knownLibraries = ImmutableList.<String>builder()
                 .addAll(modClassLoader.getDefaultLibraries())
-                .addAll(CoreModManager.getLibraries())
+                .addAll(CoreModManager.getLoadedCoremods())
                 .build();
         File[] minecraftSources = modClassLoader.getParentSources();
         if (minecraftSources.length == 1 && minecraftSources[0].isFile())


### PR DESCRIPTION
Allows ModDiscoverer to read mods from symlinks, this allows for shared mods between various instances of minecraft, for example.

I'm not very experienced in IO, so this code might not be the most correct or optimal, feel free to correct me at need.
