### PR TITLE
@InstanceFactory was set to look for Fields instead of methods

### DIFF
--- a/common/cpw/mods/fml/common/Mod.java
+++ b/common/cpw/mods/fml/common/Mod.java
@@ -424,7 +424,7 @@ public @interface Mod
      *
      */
     @Retention(RetentionPolicy.RUNTIME)
-    @Target(ElementType.FIELD)
+    @Target(ElementType.METHOD)
     public @interface InstanceFactory {
     }
 }


### PR DESCRIPTION
"fixed it" to now match the javadoc :P

if it was set like that so modders wouldn't use it, it might be better to just say so in the documentation
