### PR TITLE
Update LanguageRegistry.java

### DIFF
--- a/common/cpw/mods/fml/common/registry/LanguageRegistry.java
+++ b/common/cpw/mods/fml/common/registry/LanguageRegistry.java
@@ -46,7 +46,12 @@ public class LanguageRegistry
 
     public String getStringLocalization(String key)
     {
-        return getStringLocalization(key, Minecraft.func_71410_x().func_135016_M().func_135041_c().func_135034_a());
+        try {
+        	return getStringLocalization(key, Minecraft.getMinecraft().func_135016_M().func_135041_c().func_135034_a());
+    	}
+        catch (NoClassDefFoundError e) {
+    		return getStringLocalization(key, "en_US");
+    	}
     }
 
     public String getStringLocalization(String key, String lang)


### PR DESCRIPTION
Surround the getLocalization(key) logic in a basic try/catch to default to checking the en_US localization in the event that it can't find the current localization (ie, server side)
