### PR TITLE
Add missing SideOnly in BaseMod

### DIFF
--- a/client/net/minecraft/src/BaseMod.java
+++ b/client/net/minecraft/src/BaseMod.java
@@ -448,6 +448,7 @@ public abstract class BaseMod implements cpw.mods.fml.common.modloader.BaseModPr
         return null;
     }
 
+    @SideOnly(CLIENT)
     public void clientCustomPayload(NetClientHandler handler, Packet250CustomPayload packet)
     {
 


### PR DESCRIPTION
NetClientHandler exists only on client side and thus method using it should be annotated with SideOnly.
