### PR TITLE
Fixed install.sh not passing arguments to install.py

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-python install.py
+python install.py "$@"


### PR DESCRIPTION
You should now be able to pass arguments through install.sh now.

```
bash ./install.sh --no-assets
```
