### PR TITLE
Included scala library in 1.6.2 release json

### DIFF
--- a/jsons/1.6.2-rel.json
+++ b/jsons/1.6.2-rel.json
@@ -28,7 +28,7 @@
       },
       {
         "name": "org.scala-lang:scala-library:2.10.2",
-        "url" : "http://repo.maven.apache.org/maven2",
+        "url" : "http://repo.maven.apache.org/maven2/",
         "comment" : "Important for FML, we add this",
         "serverreq":true
       },


### PR DESCRIPTION
The scala library should be included in runtime. Else all scala mods that use those libraries will crash.
