### PR TITLE
Added null checks for ModList packets

### DIFF
--- a/common/cpw/mods/fml/common/network/ModListRequestPacket.java
+++ b/common/cpw/mods/fml/common/network/ModListRequestPacket.java
@@ -112,6 +112,11 @@ public class ModListRequestPacket extends FMLPacket
                 if (e.getValue().isNetworkMod())
                 {
                     NetworkModHandler missingHandler = FMLNetworkHandler.instance().findNetworkModHandler(e.getValue());
+                    if (missingHandler==null)
+                    {
+                        FMLLog.warning("The mod %s has a null NetworkModHandler!", modVersion.getKey());
+                        continue;
+                    }
                     if (missingHandler.requiresServerSide())
                     {
                         // TODO : what should we do if a mod is marked "serverSideRequired"? Stop the connection?

--- a/common/cpw/mods/fml/common/network/ModListResponsePacket.java
+++ b/common/cpw/mods/fml/common/network/ModListResponsePacket.java
@@ -112,6 +112,11 @@ public class ModListResponsePacket extends FMLPacket
         {
             ModContainer mc = indexedModList.get(modVersion.getKey());
             NetworkModHandler networkMod = handler.findNetworkModHandler(mc);
+            if (networkMod==null)
+            {
+                FMLLog.warning("The mod %s has a null NetworkModHandler!", modVersion.getKey());
+                continue;
+            }
             if (!networkMod.acceptVersion(modVersion.getValue()))
             {
                 versionIncorrectMods.add(modVersion.getKey());


### PR DESCRIPTION
ModListRequestPacket and ModListResponsePacket were vulnerable to a null NetworkModHandler (i.e., it would crash the client), so I just added a check and continue if the NetworkModHandler is null.
