### PR TITLE
update findContainerFor() to work on core mods

### DIFF
--- a/common/cpw/mods/fml/common/FMLCommonHandler.java
+++ b/common/cpw/mods/fml/common/FMLCommonHandler.java
@@ -156,6 +156,12 @@ public class FMLCommonHandler
      */
     public ModContainer findContainerFor(Object mod)
     {
+        // allow this method to work on core mods
+        if( mod instanceof ModContainer )
+        {
+            return (ModContainer)mod;
+        }
+        
         return Loader.instance().getReversedModObjectList().get(mod);
     }
     /**


### PR DESCRIPTION
Hello,

Here's a pull request so that core mods can register entities,guis,etc. Right now, the registrations methods crash because findContainerFor() returns null on core mods.

I started a thread on the forums about it. You can find more info there.
http://www.minecraftforge.net/forum/index.php/topic,11343.0.html

Thanks,
Cuchaz
