### PR TITLE
Fix NPE when loading second single-player world

### DIFF
--- a/client/cpw/mods/fml/client/FMLClientHandler.java
+++ b/client/cpw/mods/fml/client/FMLClientHandler.java
@@ -617,9 +617,11 @@ public class FMLClientHandler implements IFMLSidedHandler
     public void serverStopped()
     {
         // If the server crashes during startup, it might hang the client- reset the client so it can abend properly.
-        if (!getServer().func_71200_ad())
+        MinecraftServer server = getServer();
+
+        if (server != null && !server.func_71200_ad())
         {
-            ObfuscationReflectionHelper.setPrivateValue(MinecraftServer.class, getServer(), true, "field_71296"+"_Q","serverIs"+"Running");
+            ObfuscationReflectionHelper.setPrivateValue(MinecraftServer.class, server, true, "field_71296"+"_Q","serverIs"+"Running");
         }
     }
 }


### PR DESCRIPTION
_Steps to reproduce_
- Have two single-player worlds
- Start a single-player game in the first world
- Press Esc, "Save and quit"
- Start a single-player game in the second world

_Expected result_
- Second world loads correctly

_Actual result_
- GUI screen stops at an empty dirt background, before the point at which loading messages start to appear
- Debug log shows the stack trace and errors mentioned in the commit message below

The patch gives the expected result.

---

After leaving a single-player world, getServer() can return null, resulting
in the stack trace below, "Fatal errors were detected during the
transition from SERVER_STOPPING to SERVER_ABOUT_TO_START",
"The ForgeModLoader state engine has become corrupted" and the client
getting stuck forever.

Exception in thread "Server thread" java.lang.NullPointerException
at cpw.mods.fml.client.FMLClientHandler.serverStopped(FMLClientHandler.java:620)
at cpw.mods.fml.common.FMLCommonHandler.handleServerStopped(FMLCommonHandler.java:468)
at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:471)
at net.minecraft.server.ThreadMinecraftServer.run(SourceFile:583)
