### PR TITLE
Fix isRepeat value for keyDown()

### DIFF
--- a/client/cpw/mods/fml/client/registry/KeyBindingRegistry.java
+++ b/client/cpw/mods/fml/client/registry/KeyBindingRegistry.java
@@ -122,7 +122,7 @@ public class KeyBindingRegistry
                 {
                     if (state)
                     {
-                        keyDown(type, keyBinding, tickEnd, state!=keyDown[i]);
+                        keyDown(type, keyBinding, tickEnd, state==keyDown[i]);
                     }
                     else
                     {


### PR DESCRIPTION
When state == keyDown[i], then isRepeat should be true. When state != keyDown[i], then isRepeat should be false. The current code passes isRepeat == true on the first call to keyDown().

If I'm completely misunderstanding this code, then please enlighten me... it seems like keyDown() should be getting isRepeat == false on the first call and isRepeat == true on subsequent calls.
