### PR TITLE
Support for multiple interface removals

### DIFF
--- a/common/cpw/mods/fml/common/Optional.java
+++ b/common/cpw/mods/fml/common/Optional.java
@@ -18,7 +18,7 @@ public final class Optional {
      */
     private Optional() {}
     /**
-     * Used to remove optional interfaces
+     * Used to remove an optional interface
      * @author cpw
      *
      */
@@ -36,6 +36,15 @@ public final class Optional {
          * @return the modid
          */
         public String modid();
+    }
+    /**
+     * Used to remove multiple optional interfaces
+     *
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE)
+    public @interface Interfaces {
+        public Optional.Interface[] value();        
     }
     /**
      * Used to remove optional methods


### PR DESCRIPTION
Currently, since annotations cannot be duplicated in Java, only a single interface can be removed on a class. That is very inflexible if a mod author needs to remove more than 1 interface. This pull request adds the ability for more than 1 interface to be removed on a class. The usage is simple a wrapper of the currently existing @Optional.Interface except in an array.

Example code is as follows:

```
@Optional.Interfaces({@Optional.Interface(modid = "modA", iface = "interfaceA"), @Optional.Interface(modid = "modB", iface = "interfaceB")})
```
