### PR TITLE
Fix VersionCheckHandler javadoc comment

### DIFF
--- a/common/cpw/mods/fml/common/network/NetworkMod.java
+++ b/common/cpw/mods/fml/common/network/NetworkMod.java
@@ -75,7 +75,7 @@ public @interface NetworkMod
     /**
      * A marker for a method that will be offered the client's version string
      * if more sophisticated version rejection handling is required:
-     * The method should accept a "String", a "NetworkManager" and return a boolean true
+     * The method should accept a "String" (The client version) and return a boolean true
      * if the version can be accepted.
      * @author cpw
      *


### PR DESCRIPTION
VersionCheckHandler caused some confusion to me, because it wasn't working. After looking in the code i saw that the expected signature was changed.
The code was only searching for methods with a String argument, the NetworkManager part is gone.
