### PR TITLE
Don't search for mods in the java files

### DIFF
--- a/common/cpw/mods/fml/common/discovery/JarDiscoverer.java
+++ b/common/cpw/mods/fml/common/discovery/JarDiscoverer.java
@@ -59,7 +59,7 @@ public class JarDiscoverer implements ITypeDiscoverer
             }
             for (ZipEntry ze : Collections.list(jar.entries()))
             {
-                if (ze.getName()!=null && ze.getName().startsWith("__MACOSX"))
+                if (ze.getName()!=null && (ze.getName().startsWith("__MACOSX") || ze.getName().startsWith("java/")))
                 {
                     continue;
                 }


### PR DESCRIPTION
Prevents weird exceptions like http://hastebin.reening.nl/huleharedi.txt while starting client or server
