### PR TITLE
Fix python.exe for modern distros that ship python 3+ as default

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -31,7 +31,7 @@
     </condition>
     <property name="fml.python.dir" location="${basedir}/python" />
     <property name="fml.lzma.dir" location="${basedir}/lzmabin" />
-    <condition property="python.exe" value="${fml.python.dir}/python_fml" else="python">
+    <condition property="python.exe" value="${fml.python.dir}/python_fml" else="python2">
       <os family="Windows" />
     </condition>
     <condition property="lzma.exe" value="${fml.lzma.dir}/xz.exe" else="xz">


### PR DESCRIPTION
Until scripts are compatible with python 3, it is better to explicitly call `python2` instead of just `python` as more and more distros are starting to ship python3 as the default python implementation.
