### PR TITLE
Fixed potential unmappable character error

### DIFF
--- a/common/cpw/mods/fml/common/versioning/ComparableVersion.java
+++ b/common/cpw/mods/fml/common/versioning/ComparableVersion.java
@@ -68,7 +68,7 @@ import java.util.Stack;
  *
  * @see <a href="https://cwiki.apache.org/confluence/display/MAVENOLD/Versioning">"Versioning" on Maven Wiki</a>
  * @author <a href="mailto:kenney@apache.org">Kenney Westerhof</a>
- * @author <a href="mailto:hboutemy@apache.org">Hervé Boutemy</a>
+ * @author <a href="mailto:hboutemy@apache.org">Herve Boutemy</a>
  */
 public class ComparableVersion
     implements Comparable<ComparableVersion>


### PR DESCRIPTION
As I compiled my scala mod I recieved "error: unmappable character for encoding UTF-8" regarding the 'é' symbol. Changing it to 'e' fixed it. There is probably a better workaround on my end but this does the trick.
