### PR TITLE
Use custom Comparator<File> to enforce platform-independent alpha sort

### DIFF
--- a/common/cpw/mods/fml/common/discovery/ModDiscoverer.java
+++ b/common/cpw/mods/fml/common/discovery/ModDiscoverer.java
@@ -91,9 +91,9 @@ public class ModDiscoverer
         Arrays.sort(modList, new Comparator<File>() {
             @Override
             public int compare(File o1, File o2) {
-                String p1 = o1.getAbsolutePath().toLowerCase();
-                String p2 = o2.getAbsolutePath().toLowerCase();
-                return p1.compareTo(p2);
+                String p1 = o1.getAbsolutePath();
+                String p2 = o2.getAbsolutePath()
+                return p1.compareToIgnoreCase(p2);
             }
         });
 


### PR DESCRIPTION
This change will ensure that the initial mod sorting is consistent across platforms.
