### PR TITLE
Optional: automatically strip methods if they use a stripped interface in their signature.

### DIFF
--- a/common/cpw/mods/fml/common/Optional.java
+++ b/common/cpw/mods/fml/common/Optional.java
@@ -51,6 +51,15 @@ public final class Optional {
          * @return the modid
          */
         public String modid();
+
+        /**
+         * Also strip any methods in the class that use the specified interface
+         * in their signature. This does <em>not</em> strip methods defined in
+         * the specified interface, but methods defined in the class that use
+         * the interface in their signature, meaning either as a parameter or
+         * as return type.
+         */
+        public boolean methods() default false;
     }
     /**
      * Used to remove optional methods


### PR DESCRIPTION
I think it can generally be said that if an interface is stripped from a class, methods in that class using that interface in their signature should also be stripped, since the only real reason to strip an interface would be that the interface isn't available due to the providing mod not being installed. So I propose to automatically strip all methods that do use a stripped interface from the class, too.

If you want to have this option via an additional annotation before you consider merging it I'll gladly have a look into that, I just wanted to keep the change minimal before knowing whether this has any chance at all to make it in.
