### PR TITLE
Add in null protection for client/server sides of handleChat

### DIFF
--- a/patches/minecraft/net/minecraft/client/multiplayer/NetClientHandler.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/NetClientHandler.java.patch
@@ -64,15 +64,19 @@
          }
      }
  
-@@ -804,6 +814,7 @@
+@@ -804,7 +814,11 @@
  
      public void func_72481_a(Packet3Chat p_72481_1_)
      {
 +        p_72481_1_ = FMLNetworkHandler.handleChatMessage(this, p_72481_1_);
++        if (p_72481_1_ != null)
++        {
          this.field_72563_h.field_71456_v.func_73827_b().func_73765_a(ChatMessageComponent.func_111078_c(p_72481_1_.field_73476_b).func_111068_a(true));
++        }
      }
  
-@@ -1403,6 +1414,11 @@
+     public void func_72524_a(Packet18Animation p_72524_1_)
+@@ -1403,6 +1417,11 @@
  
      public void func_72494_a(Packet131MapData p_72494_1_)
      {
@@ -84,7 +88,7 @@
          if (p_72494_1_.field_73438_a == Item.field_77744_bd.field_77779_bT)
          {
              ItemMap.func_77874_a(p_72494_1_.field_73436_b, this.field_72563_h.field_71441_e).func_76192_a(p_72494_1_.field_73437_c);
-@@ -1514,6 +1530,11 @@
+@@ -1514,6 +1533,11 @@
  
      public void func_72501_a(Packet250CustomPayload p_72501_1_)
      {
@@ -96,7 +100,7 @@
          if ("MC|TrList".equals(p_72501_1_.field_73630_a))
          {
              DataInputStream datainputstream = new DataInputStream(new ByteArrayInputStream(p_72501_1_.field_73629_c));
-@@ -1707,4 +1728,20 @@
+@@ -1707,4 +1731,20 @@
      {
          return this.field_72555_g;
      }

--- a/patches/minecraft/net/minecraft/network/NetServerHandler.java.patch
+++ b/patches/minecraft/net/minecraft/network/NetServerHandler.java.patch
@@ -17,15 +17,38 @@
  import net.minecraft.network.packet.Packet13PlayerLookMove;
  import net.minecraft.network.packet.Packet14BlockDig;
  import net.minecraft.network.packet.Packet15Place;
-@@ -618,6 +621,7 @@
+@@ -618,6 +621,10 @@
  
      public void func_72481_a(Packet3Chat p_72481_1_)
      {
 +        p_72481_1_ = FMLNetworkHandler.handleChatMessage(this, p_72481_1_);
++        
++        if (p_72481_1_ != null)
++        {
          if (this.field_72574_e.func_71126_v() == 2)
          {
              this.func_72567_b(new Packet3Chat(ChatMessageComponent.func_111077_e("chat.cannotSend").func_111059_a(EnumChatFormatting.RED)));
-@@ -1013,6 +1017,11 @@
+@@ -635,6 +642,8 @@
+             {
+                 s = StringUtils.normalizeSpace(s);
+ 
++                if (s != null)
++                {
+                 for (int i = 0; i < s.length(); ++i)
+                 {
+                     if (!ChatAllowedCharacters.func_71566_a(s.charAt(i)))
+@@ -666,7 +675,9 @@
+                 {
+                     this.func_72565_c("disconnect.spam");
+                 }
+-            }
++                }
++            }
++        }
+         }
+     }
+ 
+@@ -1013,6 +1024,11 @@
      }
  
      public void func_72501_a(Packet250CustomPayload p_72501_1_)
@@ -37,7 +60,7 @@
      {
          DataInputStream datainputstream;
          ItemStack itemstack;
-@@ -1182,4 +1191,18 @@
+@@ -1182,4 +1198,18 @@
      {
          return this.field_72576_c;
      }


### PR DESCRIPTION
Adds the ability to cancel a chat message by setting packet (or the string message within it) to null
