### PR TITLE
add AssetsDir decleration to shipped Build.gradle

### DIFF
--- a/install/build.gradle
+++ b/install/build.gradle
@@ -19,6 +19,7 @@ archivesBaseName = "modid"
 
 minecraft {
 	version = "${version}"
+	assetDir = "eclipse/assets"
 }
 
 processResources


### PR DESCRIPTION
Its really not a sensative default to be pushing on EVERYONE, so this limits this location to only thos using the src download. everyone else can have something sensible like run/assets or something..
