### PR TITLE
Check if playerNetServerHandler is null before sending the packet.

### DIFF
--- a/src/main/java/cpw/mods/fml/common/network/PacketDispatcher.java
+++ b/src/main/java/cpw/mods/fml/common/network/PacketDispatcher.java
@@ -40,7 +40,7 @@ public class PacketDispatcher
 
     public static void sendPacketToPlayer(Packet packet, Player player)
     {
-        if (player instanceof EntityPlayerMP)
+        if (player instanceof EntityPlayerMP && (EntityPlayerMP)player).field_71135_a != null)
         {
             ((EntityPlayerMP)player).field_71135_a.func_72567_b(packet);
         }


### PR DESCRIPTION
Helps prevent crashes of accidentally sending packets to FakePlayer, who's playerNetServerHandler is null.
