### PR TITLE
Add INetHandler argument to packet helper decode.

### DIFF
--- a/src/main/java/cpw/mods/fml/common/network/FMLIndexedMessageToMessageCodec.java
+++ b/src/main/java/cpw/mods/fml/common/network/FMLIndexedMessageToMessageCodec.java
@@ -38,7 +38,7 @@ public abstract class FMLIndexedMessageToMessageCodec<A> extends MessageToMessag
         out.add(proxy);
     }
 
-    public abstract void decodeInto(ChannelHandlerContext ctx, ByteBuf source, A msg);
+    public abstract void decodeInto(ChannelHandlerContext ctx, ByteBuf source, A msg, INetHandler handler);
 
     @Override
     protected final void decode(ChannelHandlerContext ctx, FMLProxyPacket msg, List<Object> out) throws Exception
@@ -47,7 +47,7 @@ public abstract class FMLIndexedMessageToMessageCodec<A> extends MessageToMessag
         byte discriminator = payload.readByte();
         Class<? extends A> clazz = discriminators.get(discriminator);
         A newMsg = clazz.newInstance();
-        decodeInto(ctx, payload.slice(), newMsg);
+        decodeInto(ctx, payload.slice(), newMsg, msg.handler());
         out.add(newMsg);
     }
 }

--- a/src/main/java/cpw/mods/fml/common/network/internal/FMLRuntimeCodec.java
+++ b/src/main/java/cpw/mods/fml/common/network/internal/FMLRuntimeCodec.java
@@ -19,7 +19,7 @@ public class FMLRuntimeCodec extends FMLIndexedMessageToMessageCodec<FMLMessage>
     }
 
     @Override
-    public void decodeInto(ChannelHandlerContext ctx, ByteBuf source, FMLMessage msg)
+    public void decodeInto(ChannelHandlerContext ctx, ByteBuf source, FMLMessage msg, INetHandler handler)
     {
         msg.fromBytes(source);
     }


### PR DESCRIPTION
There doesn't seem to be a consistent way of getting this info when
recieving a packet. Vanilla passes it around but it gets dropped at
this point. The handshake messages set it on the context, but there's
only one context per EmbeededChannel so they will overwrite eachother.
