### PR TITLE
Fix MinecraftForge/ForgeGradle#34

### DIFF
--- a/jsons/1.7.2-dev.json
+++ b/jsons/1.7.2-dev.json
@@ -144,7 +144,7 @@
       }
     },
     {
-      "name": "org.lwjgl.lwjgl:lwjgl:2.9.1-nightly-20131017",
+      "name": "org.lwjgl.lwjgl:lwjgl:2.9.0",
       "rules": [
         {
           "action": "allow",
@@ -155,7 +155,7 @@
       ]
     },
     {
-      "name": "org.lwjgl.lwjgl:lwjgl_util:2.9.1-nightly-20131017",
+      "name": "org.lwjgl.lwjgl:lwjgl_util:2.9.0",
       "rules": [
         {
           "action": "allow",
@@ -166,7 +166,7 @@
       ]
     },
     {
-      "name": "org.lwjgl.lwjgl:lwjgl-platform:2.9.1-nightly-20131017",
+      "name": "org.lwjgl.lwjgl:lwjgl-platform:2.9.0",
       "rules": [
         {
           "action": "allow",


### PR DESCRIPTION
Because mojang removed the old lwjgl-nightly-20131017 from their maven servers, gradle crashes on macs.
This fixes MinecraftForge/ForgeGradle#34 and is a working replacement for #321
