### PR TITLE
Avoiding redundant calls to LogManager

### DIFF
--- a/src/main/java/cpw/mods/fml/relauncher/FMLRelaunchLog.java
+++ b/src/main/java/cpw/mods/fml/relauncher/FMLRelaunchLog.java
@@ -44,6 +44,7 @@ public class FMLRelaunchLog {
     private static void configureLogging()
     {
         log.myLog = LogManager.getLogger("FML");
+        configured = true;
     }
 
     public static void log(String targetLog, Level level, String format, Object... data)


### PR DESCRIPTION
Super minor omission results in multiple redundant calls to LogManager.  Shouldn't be a real issue, just noticed it while looking through the log4j stuff.
