### PR TITLE
added override toString method for getting full name.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -80,7 +80,7 @@ Standalone source installation
 ==============================
 
 To install this source code for development purposes, extract this zip file.
-It ships with a demonstration mod. Run "gradle setupFML" to create
+It ships with a demonstration mod. Run "gradle setupDevWorkspace" to create
 a gradle environment primed with FML. Run gradle eclipse or gradle idea to
 create an IDE workspace of your choice.
 Refer to ForgeGradle for more information about the gradle environment


### PR DESCRIPTION
I added an override method toString in GameRegistry.UniqueIdentifier for more easily getting the original modId:name of the registered block/item. I also saw that setupDevWorkspace is not a task for FML and instead it is setupFML so I changed the readme to reflect that.
