### PR TITLE
use correct KeyBinding array in GameSettings

### DIFF
--- a/src/main/java/cpw/mods/fml/client/registry/ClientRegistry.java
+++ b/src/main/java/cpw/mods/fml/client/registry/ClientRegistry.java
@@ -46,6 +46,6 @@ public class ClientRegistry
 
     public static void registerKeyBinding(KeyBinding key)
     {
-        Minecraft.func_71410_x().field_71474_y.field_151456_ac = ArrayUtils.add(Minecraft.func_71410_x().field_71474_y.field_151456_ac, key);
+        Minecraft.func_71410_x().field_71474_y.field_74324_K = ArrayUtils.add(Minecraft.func_71410_x().field_71474_y.field_74324_K, key);
     }
 }


### PR DESCRIPTION
registerKeyBinding() appears to be using the wrong KeyBinding array from GameSettings. field_74324_K is the array that is used in loadOptions(). field_151456_ac is a temporary array that is only used in the GameSettings constructor. This mix-up results in registered keybindings not showing up on the options screen.
