### PR TITLE
TickEvent.Type to public and remove to the unnecessary static.

### DIFF
--- a/src/main/java/cpw/mods/fml/common/gameevent/TickEvent.java
+++ b/src/main/java/cpw/mods/fml/common/gameevent/TickEvent.java
@@ -7,7 +7,7 @@ import cpw.mods.fml.common.eventhandler.Event;
 import cpw.mods.fml.relauncher.Side;
 
 public class TickEvent extends Event {
-    private static enum Type {
+    public enum Type {
         WORLD, PLAYER, CLIENT, SERVER, RENDER;
     }
 


### PR DESCRIPTION
the TickEvent#type field have been published, but could not compare by enum.
