### PR TITLE
modify to be able to set the SideProxy even if the target field is not published.

### DIFF
--- a/src/main/java/cpw/mods/fml/common/ProxyInjector.java
+++ b/src/main/java/cpw/mods/fml/common/ProxyInjector.java
@@ -67,6 +67,7 @@ public class ProxyInjector
                     FMLLog.severe("Attempted to load a proxy type %s into %s.%s, but the types don't match", targetType, targ.getClassName(), targ.getObjectName());
                     throw new LoaderException();
                 }
+                target.setAccessible(true);
                 languageAdapter.setProxy(target, proxyTarget, proxy);
             }
             catch (Exception e)


### PR DESCRIPTION
I think the fields that have been annotated with a @SideProxy, should I be injected even if it is not published.
In the same way as @Mod.Instance and @Mod.Metadata..

//sorry, I'm poor at English.
