### PR TITLE
Work around OSX build problem

### DIFF
--- a/jsons/1.7.2-dev.json
+++ b/jsons/1.7.2-dev.json
@@ -144,7 +144,7 @@
       }
     },
     {
-      "name": "org.lwjgl.lwjgl:lwjgl:2.9.1-nightly-20131017",
+      "name": "org.lwjgl.lwjgl:lwjgl:2.9.1",
       "rules": [
         {
           "action": "allow",
@@ -155,7 +155,7 @@
       ]
     },
     {
-      "name": "org.lwjgl.lwjgl:lwjgl_util:2.9.1-nightly-20131017",
+      "name": "org.lwjgl.lwjgl:lwjgl_util:2.9.1",
       "rules": [
         {
           "action": "allow",
@@ -166,7 +166,7 @@
       ]
     },
     {
-      "name": "org.lwjgl.lwjgl:lwjgl-platform:2.9.1-nightly-20131017",
+      "name": "org.lwjgl.lwjgl:lwjgl-platform:2.9.1",
       "rules": [
         {
           "action": "allow",


### PR DESCRIPTION
This change is needed to build fml on OSX. Others have been using it on the minecraftforge forums.
