### PR TITLE
Throw an exception when discriminator is not found

### DIFF
--- a/src/main/java/cpw/mods/fml/common/network/FMLIndexedMessageToMessageCodec.java
+++ b/src/main/java/cpw/mods/fml/common/network/FMLIndexedMessageToMessageCodec.java
@@ -46,6 +46,10 @@ public abstract class FMLIndexedMessageToMessageCodec<A> extends MessageToMessag
         ByteBuf payload = msg.payload();
         byte discriminator = payload.readByte();
         Class<? extends A> clazz = discriminators.get(discriminator);
+        if(clazz == null)
+        {
+            throw new NullPointerException("Undefined message for discriminator " + discriminator + " in channel " + msg.channel());
+        }
         A newMsg = clazz.newInstance();
         decodeInto(ctx, payload.slice(), newMsg);
         out.add(newMsg);


### PR DESCRIPTION
Instead of letting it fail 1 line lower with a NullPointerException, which will be thrown as a netty DecoderException, be informative to the user, which discriminator is missing and in which channel.
