### PR TITLE
Don't restrict EventBus registration to init phase

### DIFF
--- a/src/main/java/cpw/mods/fml/common/eventhandler/EventBus.java
+++ b/src/main/java/cpw/mods/fml/common/eventhandler/EventBus.java
@@ -11,6 +11,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import com.google.common.collect.MapMaker;
 import com.google.common.reflect.TypeToken;
+import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.ModContainer;
 
@@ -26,15 +27,25 @@ public class EventBus
     {
         ListenerList.resize(busID + 1);
     }
-
-    public void register(Object target)
+    
+    public void register(Object target, Object mod)
     {
         if (listeners.containsKey(target))
         {
             return;
         }
+        
+        ModContainer targetContainer;
+        if (mod instanceof ModContainer)
+        {
+            targetContainer = (ModContainer) mod;
+        }
+        else
+        {
+            targetContainer = FMLCommonHandler.instance().findContainerFor(mod);
+        }
 
-        listenerOwners.put(target, Loader.instance().activeModContainer());
+        listenerOwners.put(target, targetContainer);
         Set<? extends Class<?>> supers = TypeToken.of(target.getClass()).getTypes().rawTypes();
         for (Method method : target.getClass().getMethods())
         {
@@ -71,6 +82,11 @@ public class EventBus
                 }
             }
         }
+    }
+    
+    public void register(Object target)
+    {
+        this.register(target, Loader.instance().activeModContainer());
     }
 
     private void register(Class<?> eventType, Object target, Method method, ModContainer owner)


### PR DESCRIPTION
After the logging stuff added in 8692ca17d13eda036b5ef996ec8e8706e7707d80, we weren't able to register stuff into the eventbus after the game is started. This is needed for some things. I, for example, give each world some helper objects which track some statistics and listen to events. This won't work after said commit. Same for things the ForgeEssentials guys are planning with their module loading system. When they aren't able to add things to the eventbus when the game is started, that entire plan won't work.
