### PR TITLE
Prevent players from logging in until server has finished starting.

### DIFF
--- a/patches/minecraft/net/minecraft/server/dedicated/DedicatedServer.java.patch
+++ b/patches/minecraft/net/minecraft/server/dedicated/DedicatedServer.java.patch
@@ -7,7 +7,15 @@
  import cpw.mods.fml.relauncher.Side;
  import cpw.mods.fml.relauncher.SideOnly;
  import java.io.BufferedReader;
-@@ -109,6 +110,8 @@
+@@ -45,6 +46,7 @@
+     private boolean field_71338_p;
+     private WorldSettings.GameType field_71337_q;
+     private boolean field_71335_s;
++    public static boolean allowPlayerLogins = false;
+     private static final String __OBFID = "CL_00001784";
+ 
+     public DedicatedServer(File p_i1508_1_)
+@@ -109,6 +111,8 @@
              field_155771_h.warn("To start the server with more ram, launch it as \"java -Xmx1024M -Xms1024M -jar minecraft_server.jar\"");
          }
  
@@ -16,7 +24,7 @@
          field_155771_h.info("Loading properties");
          this.field_71340_o = new PropertyManager(new File("server.properties"));
  
-@@ -180,6 +183,8 @@
+@@ -180,6 +184,8 @@
              field_155771_h.warn("To change this, set \"online-mode\" to \"true\" in the server.properties file.");
          }
  
@@ -25,7 +33,7 @@
          this.func_71210_a(new DedicatedPlayerList(this));
          long j = System.nanoTime();
  
-@@ -225,6 +230,7 @@
+@@ -225,6 +231,7 @@
          this.func_71191_d((this.func_71207_Z() + 8) / 16 * 16);
          this.func_71191_d(MathHelper.func_76125_a(this.func_71207_Z(), 64, 256));
          this.field_71340_o.func_73667_a("max-build-height", Integer.valueOf(this.func_71207_Z()));
@@ -33,11 +41,12 @@
          field_155771_h.info("Preparing level \"" + this.func_71270_I() + "\"");
          this.func_71247_a(this.func_71270_I(), this.func_71270_I(), k, worldtype, s2);
          long i1 = System.nanoTime() - j;
-@@ -245,7 +251,7 @@
+@@ -245,7 +252,8 @@
              this.field_71339_n.func_72602_a();
          }
  
 -        return true;
++        allowPlayerLogins = true;
 +        return FMLCommonHandler.instance().handleServerStarting(this);
      }
  

--- a/patches/minecraft/net/minecraft/server/network/NetHandlerHandshakeTCP.java.patch
+++ b/patches/minecraft/net/minecraft/server/network/NetHandlerHandshakeTCP.java.patch
@@ -1,0 +1,25 @@
+--- ../src-base/minecraft/net/minecraft/server/network/NetHandlerHandshakeTCP.java
++++ ../src-work/minecraft/net/minecraft/server/network/NetHandlerHandshakeTCP.java
+@@ -7,6 +7,7 @@
+ import net.minecraft.network.handshake.client.C00Handshake;
+ import net.minecraft.network.login.server.S00PacketDisconnect;
+ import net.minecraft.server.MinecraftServer;
++import net.minecraft.server.dedicated.DedicatedServer;
+ import net.minecraft.util.ChatComponentText;
+ import net.minecraft.util.IChatComponent;
+ 
+@@ -24,6 +25,14 @@
+ 
+     public void func_147383_a(C00Handshake p_147383_1_)
+     {
++        if (!DedicatedServer.allowPlayerLogins)
++        {
++            ChatComponentText chatcomponenttext = new ChatComponentText("Server is still starting! Please wait before reconnecting.");
++            this.field_147386_b.func_150725_a(new S00PacketDisconnect(chatcomponenttext), new GenericFutureListener[0]);
++            this.field_147386_b.func_150718_a(chatcomponenttext);
++            return;
++        }
++
+         switch (NetHandlerHandshakeTCP.SwitchEnumConnectionState.field_151291_a[p_147383_1_.func_149594_c().ordinal()])
+         {
+             case 1:


### PR DESCRIPTION
This improves server security as it guarantees no players will be allowed to connect until the server has fully initialized.
