### PR TITLE
Prevent player data getting reset during disconnects.

### DIFF
--- a/patches/minecraft/net/minecraft/server/management/ServerConfigurationManager.java.patch
+++ b/patches/minecraft/net/minecraft/server/management/ServerConfigurationManager.java.patch
@@ -35,7 +35,16 @@
          if (nbttagcompound != null && nbttagcompound.func_150297_b("Riding", 10))
          {
              Entity entity = EntityList.func_75615_a(nbttagcompound.func_74775_l("Riding"), worldserver);
-@@ -256,6 +259,7 @@
+@@ -225,6 +228,8 @@
+ 
+     protected void func_72391_b(EntityPlayerMP p_72391_1_)
+     {
++        if (p_72391_1_.field_71135_a == null) return;
++
+         this.field_72412_k.func_75753_a(p_72391_1_);
+         StatisticsFile statisticsfile = (StatisticsFile)this.field_148547_k.get(p_72391_1_.func_70005_c_());
+ 
+@@ -256,6 +261,7 @@
  
      public void func_72367_e(EntityPlayerMP p_72367_1_)
      {
@@ -43,7 +52,7 @@
          p_72367_1_.func_71029_a(StatList.field_75947_j);
          this.func_72391_b(p_72367_1_);
          WorldServer worldserver = p_72367_1_.func_71121_q();
-@@ -415,6 +419,7 @@
+@@ -415,6 +421,7 @@
          this.field_72404_b.add(entityplayermp1);
          entityplayermp1.func_71116_b();
          entityplayermp1.func_70606_j(entityplayermp1.func_110143_aJ());
@@ -51,7 +60,7 @@
          return entityplayermp1;
      }
  
-@@ -440,6 +445,7 @@
+@@ -440,6 +447,7 @@
              PotionEffect potioneffect = (PotionEffect)iterator.next();
              p_72356_1_.field_71135_a.func_147359_a(new S1DPacketEntityEffect(p_72356_1_.func_145782_y(), potioneffect));
          }


### PR DESCRIPTION
Since FML nulls out the player's playerNetServerHandler during login, we need to make sure that writePlayerData does not attempt to overwrite the player's dat file if the player disconnects during the "Logging In" process.
