### PR TITLE
Allow assigning a modId to a custom itemstack

### DIFF
--- a/src/main/java/cpw/mods/fml/common/registry/GameData.java
+++ b/src/main/java/cpw/mods/fml/common/registry/GameData.java
@@ -91,9 +91,13 @@ public class GameData {
         return is;
     }
 
-    static void registerCustomItemStack(String name, ItemStack itemStack)
+    static void registerCustomItemStack(String name, ItemStack itemStack, String modId)
     {
-        customItemStacks.put(Loader.instance().activeModContainer().getModId(), name, itemStack);
+        if (modId == null)
+        {
+            modId = Loader.instance().activeModContainer().getModId();
+        }
+        customItemStacks.put(modId, name, itemStack);
     }
 
     public static void dumpRegistry(File minecraftDir)

--- a/src/main/java/cpw/mods/fml/common/registry/GameRegistry.java
+++ b/src/main/java/cpw/mods/fml/common/registry/GameRegistry.java
@@ -122,9 +122,9 @@ public class GameRegistry
      * @param item The item to register
      * @param name The mod-unique name of the item
      */
-    public static void registerItem(net.minecraft.item.Item item, String name)
+    public static Item registerItem(Item item, String name)
     {
-        registerItem(item, name, null);
+        return registerItem(item, name, null);
     }
 
     /**
@@ -315,8 +315,21 @@ public class GameRegistry
 	 */
 	public static void registerCustomItemStack(String name, ItemStack itemStack)
 	{
-	    GameData.registerCustomItemStack(name, itemStack);
+	    registerCustomItemStack(name, itemStack, null);
 	}
+
+	/**
+	 * Manually register a custom item stack with FML for later tracking.
+	 *
+	 * @param name The name to register it under
+	 * @param itemStack The itemstack to register
+	 * @param modId The modId that will own the itemstack name. null defaults to the active modId
+	 */
+	public static void registerCustomItemStack(String name, ItemStack itemStack, String modId)
+	{
+	    GameData.registerCustomItemStack(name, itemStack, modId);
+	}
+
 	/**
 	 * Lookup an itemstack based on mod and name. It will create "default" itemstacks from blocks and items if no
 	 * explicit itemstack is found.


### PR DESCRIPTION
Currently you can assign a custom modId to Blocks and Items but not to
custom ItemStacks.
These changes are to allow you to do just that.

Extra:
GameRegistry.registerItem(Item, String) was changed to return the item.
This way it is consistent with the other register block/item methods.
