### PR TITLE
Initialize playClientBlock for realm connections.  Fixes #388

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/TaskOnlineConnect.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/TaskOnlineConnect.java.patch
@@ -1,0 +1,17 @@
+--- ../src-base/minecraft/net/minecraft/client/gui/TaskOnlineConnect.java
++++ ../src-work/minecraft/net/minecraft/client/gui/TaskOnlineConnect.java
+@@ -1,5 +1,6 @@
+ package net.minecraft.client.gui;
+ 
++import cpw.mods.fml.client.FMLClientHandler;
+ import cpw.mods.fml.relauncher.Side;
+ import cpw.mods.fml.relauncher.SideOnly;
+ import io.netty.util.concurrent.GenericFutureListener;
+@@ -129,6 +130,7 @@
+ 
+     private void func_148432_a(final String p_148432_1_, final int p_148432_2_)
+     {
++        FMLClientHandler.instance().connectToRealm();
+         (new Thread("MCO Connector #" + field_148439_a.incrementAndGet())
+         {
+             private static final String __OBFID = "CL_00000791";

--- a/src/main/java/cpw/mods/fml/client/FMLClientHandler.java
+++ b/src/main/java/cpw/mods/fml/client/FMLClientHandler.java
@@ -776,6 +776,11 @@ public class FMLClientHandler implements IFMLSidedHandler
         playClientBlock = new CountDownLatch(1);
     }
 
+    public void connectToRealm()
+    {
+        playClientBlock = new CountDownLatch(1);
+    }
+
     private CountDownLatch playClientBlock;
 
     public void setPlayClient(NetHandlerPlayClient netHandlerPlayClient)


### PR DESCRIPTION
Minecraft versions prior to 1.7 work fine. Tracked the bug down to playClientBlock in FMLClientHandler not being initialized because connectToServer is never called for realm server connections (nor is it appropriate).

FML and debug log available on forum: http://www.minecraftforge.net/forum/index.php/topic,16995.0.html
