### PR TITLE
Allow assigning a modId to a custom itemstack

### DIFF
--- a/src/main/java/cpw/mods/fml/common/registry/GameData.java
+++ b/src/main/java/cpw/mods/fml/common/registry/GameData.java
@@ -199,7 +199,16 @@ public class GameData {
 
     static void registerCustomItemStack(String name, ItemStack itemStack)
     {
-        customItemStacks.put(Loader.instance().activeModContainer().getModId(), name, itemStack);
+        registerCustomItemStack(name, itemStack, null);
+    }
+
+    static void registerCustomItemStack(String name, ItemStack itemStack, String modId)
+    {
+        if (modId == null)
+        {
+            modId = Loader.instance().activeModContainer().getModId();
+        }
+        customItemStacks.put(modId, name, itemStack);
     }
 
     static UniqueIdentifier getUniqueName(Block block)

--- a/src/main/java/cpw/mods/fml/common/registry/GameRegistry.java
+++ b/src/main/java/cpw/mods/fml/common/registry/GameRegistry.java
@@ -313,8 +313,21 @@ public class GameRegistry
 	 */
 	public static void registerCustomItemStack(String name, ItemStack itemStack)
 	{
-	    GameData.registerCustomItemStack(name, itemStack);
+	    registerCustomItemStack(name, itemStack, null);
 	}
+
+    /**
+     * Manually register a custom item stack with FML for later tracking.
+     * 
+     * @param name The name to register it under
+     * @param itemStack The itemstack to register
+     * @param modId The modId that will own the itemstack name. null defaults to the active modId
+     */
+    public static void registerCustomItemStack(String name, ItemStack itemStack, String modId)
+    {
+        GameData.registerCustomItemStack(name, itemStack, modId);
+    }
+
 	/**
 	 * Lookup an itemstack based on mod and name. It will create "default" itemstacks from blocks and items if no
 	 * explicit itemstack is found.


### PR DESCRIPTION
Currently you can assign a custom modId to Blocks and Items but not to custom ItemStacks.
These changes are to allow you to do just that.
