### PR TITLE
Fix server md5 check

### DIFF
--- a/mc_versions.cfg
+++ b/mc_versions.cfg
@@ -124,7 +124,7 @@ mcp_md5    = 19133b5915dc26a90d84f587172c6692
 
 [1.6.4]
 client_md5 = 2e5044f5359e82245551167a237f3167
-server_md5 = ba3145656b1480122bd8759cecd7b7a1
+server_md5 = abcf286a14f7aee82e8bf89270433509
 mcp_ver    = 8.11
 mcp_url    = http://mcp.ocean-labs.de/files/archive/mcp811.zip
 mcp_md5    = 2d7a759309b5cc10ca29caa0b10f3bfc


### PR DESCRIPTION
At some point (when?) the minecraft_server.1.6.4.jar must have changed causing installation of FML to fail.

I first noticed this issue when ProjectRed's Travis-CI failed ([link](https://travis-ci.org/MrTJP/ProjectRed/jobs/22063714)).
I know 1.6.4 is no longer the focus but for anyone wishing to use it this will fix the problem.
