### PR TITLE
Fix invalid active mod container usage

### DIFF
--- a/src/main/java/cpw/mods/fml/common/registry/FMLControlledNamespacedRegistry.java
+++ b/src/main/java/cpw/mods/fml/common/registry/FMLControlledNamespacedRegistry.java
@@ -14,6 +14,7 @@ import com.google.common.collect.ImmutableMap;
 
 import cpw.mods.fml.common.FMLLog;
 import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.common.LoadererState;
 import cpw.mods.fml.common.ModContainer;
 
 public class FMLControlledNamespacedRegistry<I> extends RegistryNamespaced {
@@ -295,7 +296,7 @@ public class FMLControlledNamespacedRegistry<I> extends RegistryNamespaced {
         }
 
         ModContainer mc = Loader.instance().activeModContainer();
-        if (mc != null)
+        if (mc != null && Loader.instance().isInState(LoaderState.PREINITIALIZATION))
         {
             String prefix = mc.getModId();
             name = prefix + ":"+ name;


### PR DESCRIPTION
In some dev environments (where all classes are in 1 directory), active mod container for FML classes (after the loading is done) would be one of those mods, which results in reregistration of all items with that mod prefix, which in turn results in unloadable worlds.
