### PR TITLE
Narrow class loader exclusions to allow org.apache.http etc

### DIFF
--- a/src/main/java/cpw/mods/fml/common/launcher/FMLTweaker.java
+++ b/src/main/java/cpw/mods/fml/common/launcher/FMLTweaker.java
@@ -104,8 +104,8 @@ public class FMLTweaker implements ITweaker {
     @Override
     public void injectIntoClassLoader(LaunchClassLoader classLoader)
     {
-        classLoader.addClassLoaderExclusion("org.apache.logging.log4j");
-        classLoader.addClassLoaderExclusion("org.apache.commons.lang3");
+        classLoader.addClassLoaderExclusion("org.apache.logging.log4j.");
+        classLoader.addClassLoaderExclusion("org.apache.commons.lang3.");
         classLoader.addTransformerExclusion("cpw.mods.fml.repackage.");
         classLoader.addTransformerExclusion("cpw.mods.fml.relauncher.");
         classLoader.addTransformerExclusion("cpw.mods.fml.common.asm.transformers.");


### PR DESCRIPTION
Currently, all of `org.apache` is excluded from the mod class loader, causing mods that use, for example, `org.apache.http`, to fail (See #424). Narrowing the exclusions to `org.apache.logging.log4j` and `org.apache.commons.lang3` fixes the issue.
