### PR TITLE
Fix ObjectIntIdentityMap sporadically matching non-identical objects.

### DIFF
--- a/patches/minecraft/net/minecraft/util/ObjectIntIdentityMap.java.patch
+++ b/patches/minecraft/net/minecraft/util/ObjectIntIdentityMap.java.patch
@@ -1,0 +1,37 @@
+--- ../src-base/minecraft/net/minecraft/util/ObjectIntIdentityMap.java
++++ ../src-work/minecraft/net/minecraft/util/ObjectIntIdentityMap.java
+@@ -2,20 +2,21 @@
+ 
+ import com.google.common.base.Predicates;
+ import com.google.common.collect.Iterators;
+-import gnu.trove.map.hash.TIntIntHashMap;
+ import java.util.ArrayList;
++import java.util.IdentityHashMap;
+ import java.util.Iterator;
+ import java.util.List;
++import java.util.Map;
+ 
+ public class ObjectIntIdentityMap implements IObjectIntIterable
+ {
+-    protected TIntIntHashMap field_148749_a = new TIntIntHashMap(256, 0.5F, -1, -1);
++    protected Map<Object, Integer> field_148749_a = new IdentityHashMap<Object, Integer>(512);
+     protected List field_148748_b = new ArrayList();
+     private static final String __OBFID = "CL_00001203";
+ 
+     public void func_148746_a(Object p_148746_1_, int p_148746_2_)
+     {
+-        this.field_148749_a.put(System.identityHashCode(p_148746_1_), p_148746_2_);
++        this.field_148749_a.put(p_148746_1_, p_148746_2_);
+ 
+         while (this.field_148748_b.size() <= p_148746_2_)
+         {
+@@ -27,7 +28,8 @@
+ 
+     public int func_148747_b(Object p_148747_1_)
+     {
+-        return this.field_148749_a.get(System.identityHashCode(p_148747_1_));
++        Integer ret = this.field_148749_a.get(p_148747_1_);
++        return ret != null ? ret : -1;
+     }
+ 
+     public Object func_148745_a(int p_148745_1_)


### PR DESCRIPTION
Fixes crashes like http://openeye.openmods.info/crashes/f53928a30b861a96a96081382dc73091
