### PR TITLE
Create RenderItem instance in ISimpleBlockRenderingHandler.java

### DIFF
--- a/src/main/java/cpw/mods/fml/client/registry/ISimpleBlockRenderingHandler.java
+++ b/src/main/java/cpw/mods/fml/client/registry/ISimpleBlockRenderingHandler.java
@@ -18,6 +18,8 @@ import net.minecraft.world.IBlockAccess;
 
 public interface ISimpleBlockRenderingHandler
 {
+    public static final RenderItem itemRenderer = new RenderItem();
+    
     public abstract void renderInventoryBlock(Block block, int metadata, int modelId, RenderBlocks renderer);
 
     public abstract boolean renderWorldBlock(IBlockAccess world, int x, int y, int z, Block block, int modelId, RenderBlocks renderer);


### PR DESCRIPTION
Many block renderers use a RenderItem instance to for their renderInventoryBlock method. Since they all need to construct a new instance at least in a static field, that is a waste of memory.
