### PR TITLE
Change Loader to give access to the mods directory variable

### DIFF
--- a/src/main/java/cpw/mods/fml/common/Loader.java
+++ b/src/main/java/cpw/mods/fml/common/Loader.java
@@ -574,6 +574,11 @@ public class Loader
     {
         return canonicalConfigDir;
     }
+    
+    public File getModDir()
+    {
+        return canonicalModsDir;
+    }
 
     public String getCrashInformation()
     {


### PR DESCRIPTION
A small change to add a getter to Loader's private canonicalModsDir File variable so mods can find the folder to store extra data.
