### PR TITLE
Add alternate KeyInputEvents for better GUI handling.

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -79,7 +79,7 @@
          Display.setVSyncEnabled(this.field_71474_y.field_74352_v);
      }
  
-@@ -916,9 +926,11 @@
+@@ -915,9 +925,11 @@
  
          if (!this.field_71454_w)
          {
@@ -91,7 +91,7 @@
          }
  
          GL11.glFlush();
-@@ -1496,6 +1508,8 @@
+@@ -1495,6 +1507,8 @@
              --this.field_71467_ac;
          }
  
@@ -100,7 +100,7 @@
          this.field_71424_I.func_76320_a("gui");
  
          if (!this.field_71445_n)
-@@ -1646,6 +1660,7 @@
+@@ -1645,6 +1659,7 @@
                          this.field_71462_r.func_146274_d();
                      }
                  }
@@ -108,7 +108,16 @@
              }
  
              if (this.field_71429_W > 0)
-@@ -1787,6 +1802,7 @@
+@@ -1768,6 +1783,8 @@
+                             {
+                                 this.field_71474_y.field_74326_T = !this.field_71474_y.field_74326_T;
+                             }
++
++                            FMLCommonHandler.instance().fireGuiKeyInput(Keyboard.getEventCharacter(), Keyboard.getEventKey());
+                         }
+ 
+                         if (this.field_71474_y.field_74330_P && this.field_71474_y.field_74329_Q)
+@@ -1786,6 +1803,7 @@
                              }
                          }
                      }
@@ -116,7 +125,7 @@
                  }
              }
  
-@@ -1978,12 +1994,15 @@
+@@ -1977,12 +1995,15 @@
              this.field_71453_ak.func_74428_b();
          }
  
@@ -132,7 +141,7 @@
          this.func_71403_a((WorldClient)null);
          System.gc();
          ISaveHandler isavehandler = this.field_71469_aa.func_75804_a(p_71371_1_, false);
-@@ -2019,6 +2038,12 @@
+@@ -2018,6 +2039,12 @@
  
          while (!this.field_71437_Z.func_71200_ad())
          {
@@ -145,7 +154,7 @@
              String s2 = this.field_71437_Z.func_71195_b_();
  
              if (s2 != null)
-@@ -2094,6 +2119,7 @@
+@@ -2093,6 +2120,7 @@
              this.field_110448_aq.func_148529_f();
              this.func_71351_a((ServerData)null);
              this.field_71455_al = false;

--- a/patches/minecraft/net/minecraft/client/gui/GuiScreen.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/GuiScreen.java.patch
@@ -1,0 +1,18 @@
+--- ../src-base/minecraft/net/minecraft/client/gui/GuiScreen.java
++++ ../src-work/minecraft/net/minecraft/client/gui/GuiScreen.java
+@@ -1,5 +1,6 @@
+ package net.minecraft.client.gui;
+ 
++import cpw.mods.fml.common.FMLCommonHandler;
+ import cpw.mods.fml.relauncher.Side;
+ import cpw.mods.fml.relauncher.SideOnly;
+ import java.awt.Toolkit;
+@@ -61,6 +62,8 @@
+             this.field_146297_k.func_147108_a((GuiScreen)null);
+             this.field_146297_k.func_71381_h();
+         }
++
++        FMLCommonHandler.instance().fireGuiKeyInput(p_73869_1_, p_73869_2_);
+     }
+ 
+     public static String func_146277_j()

--- a/src/main/java/cpw/mods/fml/common/FMLCommonHandler.java
+++ b/src/main/java/cpw/mods/fml/common/FMLCommonHandler.java
@@ -539,6 +539,11 @@ public class FMLCommonHandler
         bus().post(new InputEvent.KeyInputEvent());
     }
 
+    public void fireGuiKeyInput(char character, int key)
+    {
+        bus().post(new InputEvent.GuiKeyInputEvent(character, key));
+    }
+
     public void firePlayerChangedDimensionEvent(EntityPlayer player, int fromDim, int toDim)
     {
         bus().post(new PlayerEvent.PlayerChangedDimensionEvent(player, fromDim, toDim));

--- a/src/main/java/cpw/mods/fml/common/gameevent/InputEvent.java
+++ b/src/main/java/cpw/mods/fml/common/gameevent/InputEvent.java
@@ -5,4 +5,14 @@ import cpw.mods.fml.common.eventhandler.Event;
 public class InputEvent extends Event {
     public static class MouseInputEvent extends InputEvent {}
     public static class KeyInputEvent extends InputEvent {}
+
+    public static class GuiKeyInputEvent extends InputEvent {
+        public char character;
+        public int key;
+
+        public GuiKeyInputEvent(char ch, int k) {
+            character = ch;
+            key = k;
+        }
+    }
 }


### PR DESCRIPTION
The current event will always fire on any key input, even when
the currently active GuiScreen would rather not cause extra actions.
For example, when a GuiTextField is in focus and character input
should go to filling that and supress most other actions.

These events are separated to give a generic event for all inputs
that are not occuring with an open GuiScreen (in the main game screen)
and a separate event hooked into GuiScreen.keyTyped() as all situations
where a specific screen wants to block inputs will avoid calling
super.keyTyped() in order to avoid the vanilla bindings checked in
GuiScreen (Esc) and GuiContainer (E/Open inventory).

See also MinecraftForge/MinecraftForge#1104

(Sorry about the line changes in the patch, but genPatches seems pretty insistent on changing those)
