### PR TITLE
Implement STDOUT/STDERR redirection.

### DIFF
--- a/src/main/java/cpw/mods/fml/common/TracingPrintStream.java
+++ b/src/main/java/cpw/mods/fml/common/TracingPrintStream.java
@@ -1,0 +1,46 @@
+/*
+ * Forge Mod Loader
+ * Copyright (c) 2012-2013 cpw.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the GNU Lesser Public License v2.1
+ * which accompanies this distribution, and is available at
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ */
+
+package cpw.mods.fml.common;
+
+import java.io.PrintStream;
+
+import org.apache.logging.log4j.Logger;
+
+/**
+ * PrintStream which redirects it's output to a given logger.
+ * 
+ * @author Arkan
+ */
+public class TracingPrintStream extends PrintStream {
+    
+    private Logger logger;
+    
+    public TracingPrintStream(Logger logger, PrintStream original) {
+        super(original);
+        this.logger = logger;
+    }
+    
+    @Override
+    public void println(Object o) {
+        logger.info(getPrefix() + o);
+    }
+    
+    @Override
+    public void println(String s) {
+        logger.info(getPrefix() + s);
+    }
+    
+    private String getPrefix() {
+        StackTraceElement[] elems = Thread.currentThread().getStackTrace();
+        StackTraceElement elem = elems[3]; // The caller is always at depth 2, plus this call.
+        return "[" + elem.getClassName() + ":" + elem.getMethodName() + ":" + elem.getLineNumber() + "]: ";
+    }
+
+}

--- a/src/main/java/cpw/mods/fml/relauncher/FMLRelaunchLog.java
+++ b/src/main/java/cpw/mods/fml/relauncher/FMLRelaunchLog.java
@@ -14,10 +14,13 @@ package cpw.mods.fml.relauncher;
 
 import java.io.File;
 import java.util.Locale;
+
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
+
+import cpw.mods.fml.common.TracingPrintStream;
 
 public class FMLRelaunchLog {
 
@@ -39,13 +42,17 @@ public class FMLRelaunchLog {
     }
 
     /**
-     * Configure the FML logger
+     * Configure the FML logger and inject tracing printstreams.
      */
     private static void configureLogging()
     {
         log.myLog = LogManager.getLogger("FML");
         ThreadContext.put("side", side.name().toLowerCase(Locale.ENGLISH));
         configured = true;
+        
+        FMLRelaunchLog.fine("Injecting tracing printstreams for STDOUT/STDERR.");
+        System.setOut(new TracingPrintStream(LogManager.getLogger("STDOUT"), System.out));
+        System.setErr(new TracingPrintStream(LogManager.getLogger("STDERR"), System.err));
     }
 
     public static void log(String targetLog, Level level, String format, Object... data)


### PR DESCRIPTION
These streams now redirect to log4j2, with form `[class:method:line]: Original message`.
