### PR TITLE
Allow IMessageHandler implementations to handle multiple IMessage types

### DIFF
--- a/src/main/java/cpw/mods/fml/common/network/simpleimpl/SimpleChannelHandlerWrapper.java
+++ b/src/main/java/cpw/mods/fml/common/network/simpleimpl/SimpleChannelHandlerWrapper.java
@@ -14,9 +14,9 @@ import io.netty.channel.SimpleChannelInboundHandler;
 public class SimpleChannelHandlerWrapper<REQ extends IMessage, REPLY extends IMessage> extends SimpleChannelInboundHandler<REQ> {
     private IMessageHandler<REQ, REPLY> messageHandler;
     private Side side;
-    public SimpleChannelHandlerWrapper(Class<? extends IMessageHandler<REQ, REPLY>> handler, Side side, Class<REQ> requestType)
+    public SimpleChannelHandlerWrapper(Class<? extends IMessageHandler<REQ, REPLY>> handler, Side side, Class<? extends REQ> messageType)
     {
-        super(requestType);
+        super(messageType);
         try
         {
             messageHandler = handler.newInstance();

--- a/src/main/java/cpw/mods/fml/common/network/simpleimpl/SimpleNetworkWrapper.java
+++ b/src/main/java/cpw/mods/fml/common/network/simpleimpl/SimpleNetworkWrapper.java
@@ -93,40 +93,40 @@ public class SimpleNetworkWrapper {
      * be registered on the supplied side (this is the side where you want the message to be processed and acted upon).
      *
      * @param messageHandler the message handler type
-     * @param requestMessageType the message type
+     * @param messageType the message type
      * @param discriminator a discriminator byte
      * @param side the side for the handler
      */
-    public <REQ extends IMessage, REPLY extends IMessage> void registerMessage(Class<? extends IMessageHandler<REQ, REPLY>> messageHandler, Class<REQ> requestMessageType, int discriminator, Side side)
+    public <REQ extends IMessage, REPLY extends IMessage> void registerMessage(Class<? extends IMessageHandler<REQ, REPLY>> messageHandler, Class<? extends REQ> messageType, int discriminator, Side side)
     {
-        packetCodec.addDiscriminator(discriminator, requestMessageType);
+        packetCodec.addDiscriminator(discriminator, messageType);
         FMLEmbeddedChannel channel = channels.get(side);
         String type = channel.findChannelHandlerNameForType(SimpleIndexedCodec.class);
         if (side == Side.SERVER)
         {
-            addServerHandlerAfter(channel, type, messageHandler, requestMessageType);
+            addServerHandlerAfter(channel, type, messageHandler, messageType);
         }
         else
         {
-            addClientHandlerAfter(channel, type, messageHandler, requestMessageType);
+            addClientHandlerAfter(channel, type, messageHandler, messageType);
         }
     }
 
-    private <REQ extends IMessage, REPLY extends IMessage, NH extends INetHandler> void addServerHandlerAfter(FMLEmbeddedChannel channel, String type, Class<? extends IMessageHandler<REQ, REPLY>> messageHandler, Class<REQ> requestType)
+    private <REQ extends IMessage, REPLY extends IMessage, NH extends INetHandler> void addServerHandlerAfter(FMLEmbeddedChannel channel, String type, Class<? extends IMessageHandler<REQ, REPLY>> messageHandler, Class<? extends REQ> messageType)
     {
-        SimpleChannelHandlerWrapper<REQ, REPLY> handler = getHandlerWrapper(messageHandler, Side.SERVER, requestType);
-        channel.pipeline().addAfter(type, messageHandler.getName(), handler);
+        SimpleChannelHandlerWrapper<REQ, REPLY> handler = getHandlerWrapper(messageHandler, Side.SERVER, messageType);
+        channel.pipeline().addAfter(type, messageHandler.getName()+messageType.getName()+Side.SERVER.name(), handler);
     }
 
-    private <REQ extends IMessage, REPLY extends IMessage, NH extends INetHandler> void addClientHandlerAfter(FMLEmbeddedChannel channel, String type, Class<? extends IMessageHandler<REQ, REPLY>> messageHandler, Class<REQ> requestType)
+    private <REQ extends IMessage, REPLY extends IMessage, NH extends INetHandler> void addClientHandlerAfter(FMLEmbeddedChannel channel, String type, Class<? extends IMessageHandler<REQ, REPLY>> messageHandler, Class<? extends REQ> messageType)
     {
-        SimpleChannelHandlerWrapper<REQ, REPLY> handler = getHandlerWrapper(messageHandler, Side.CLIENT, requestType);
-        channel.pipeline().addAfter(type, messageHandler.getName(), handler);
+        SimpleChannelHandlerWrapper<REQ, REPLY> handler = getHandlerWrapper(messageHandler, Side.CLIENT, messageType);
+        channel.pipeline().addAfter(type, messageHandler.getName()+messageType.getName()+Side.CLIENT.name(), handler);
     }
 
-    private <REPLY extends IMessage, REQ extends IMessage> SimpleChannelHandlerWrapper<REQ, REPLY> getHandlerWrapper(Class<? extends IMessageHandler<REQ, REPLY>> messageHandler, Side side, Class<REQ> requestType)
+    private <REPLY extends IMessage, REQ extends IMessage> SimpleChannelHandlerWrapper<REQ, REPLY> getHandlerWrapper(Class<? extends IMessageHandler<REQ, REPLY>> messageHandler, Side side, Class<? extends REQ> messageType)
     {
-        return new SimpleChannelHandlerWrapper<REQ, REPLY>(messageHandler, side, requestType);
+        return new SimpleChannelHandlerWrapper<REQ, REPLY>(messageHandler, side, messageType);
     }
 
     /**

--- a/src/test/java/cpw/mods/fml/test/simplenet/SimpleNetHandler1.java
+++ b/src/test/java/cpw/mods/fml/test/simplenet/SimpleNetHandler1.java
@@ -8,6 +8,7 @@ public class SimpleNetHandler1 implements IMessageHandler<SimpleNetTestMessage1,
     @Override
     public SimpleNetTestMessage2 onMessage(SimpleNetTestMessage1 message, MessageContext context)
     {
+        System.out.println(this.getClass().getSimpleName() + " recieved message: " + message.getClass().getSimpleName() + " on side: " + context.side.name());
         return null;
     }
 

--- a/src/test/java/cpw/mods/fml/test/simplenet/SimpleNetHandler2.java
+++ b/src/test/java/cpw/mods/fml/test/simplenet/SimpleNetHandler2.java
@@ -8,7 +8,8 @@ public class SimpleNetHandler2 implements IMessageHandler<SimpleNetTestMessage2,
     @Override
     public SimpleNetTestMessage1 onMessage(SimpleNetTestMessage2 message, MessageContext context)
     {
-        return null;
+        System.out.println(this.getClass().getSimpleName() + " recieved message: " + message.getClass().getSimpleName() + " on side: " + context.side.name());
+        return new SimpleNetTestMessage1();
     }
 
 }

--- a/src/test/java/cpw/mods/fml/test/simplenet/SimpleNetHandlerAny.java
+++ b/src/test/java/cpw/mods/fml/test/simplenet/SimpleNetHandlerAny.java
@@ -1,0 +1,27 @@
+package cpw.mods.fml.test.simplenet;
+
+import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
+import cpw.mods.fml.common.network.simpleimpl.MessageContext;
+import cpw.mods.fml.relauncher.Side;
+
+public class SimpleNetHandlerAny implements IMessageHandler<SimpleNetTestMessageBase, SimpleNetTestMessageBase>
+{
+    private static boolean sentMessage2 = false;
+    
+    @Override
+    public SimpleNetTestMessageBase onMessage(SimpleNetTestMessageBase message, MessageContext context)
+    {
+        System.out.println(this.getClass().getSimpleName() + " recieved message: " + message.getClass().getSimpleName() + " on side: " + context.side.name());
+        
+        if (!sentMessage2 && context.side == Side.CLIENT && message instanceof SimpleNetTestMessage1)
+        {
+            sentMessage2 = true;
+            return new SimpleNetTestMessage2();
+        }
+        else if (context.side == Side.SERVER)
+            return new SimpleNetTestMessage1();
+        else
+            return null;
+    }
+
+}

--- a/src/test/java/cpw/mods/fml/test/simplenet/SimpleNetTestMessage1.java
+++ b/src/test/java/cpw/mods/fml/test/simplenet/SimpleNetTestMessage1.java
@@ -3,7 +3,7 @@ package cpw.mods.fml.test.simplenet;
 import io.netty.buffer.ByteBuf;
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 
-public class SimpleNetTestMessage1 implements IMessage {
+public class SimpleNetTestMessage1 extends SimpleNetTestMessageBase {
     @Override
     public void fromBytes(ByteBuf buf)
     {

--- a/src/test/java/cpw/mods/fml/test/simplenet/SimpleNetTestMessage2.java
+++ b/src/test/java/cpw/mods/fml/test/simplenet/SimpleNetTestMessage2.java
@@ -3,7 +3,7 @@ package cpw.mods.fml.test.simplenet;
 import io.netty.buffer.ByteBuf;
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 
-public class SimpleNetTestMessage2 implements IMessage {
+public class SimpleNetTestMessage2 extends SimpleNetTestMessageBase {
 
     @Override
     public void fromBytes(ByteBuf buf)

--- a/src/test/java/cpw/mods/fml/test/simplenet/SimpleNetTestMessageBase.java
+++ b/src/test/java/cpw/mods/fml/test/simplenet/SimpleNetTestMessageBase.java
@@ -1,0 +1,7 @@
+package cpw.mods.fml.test.simplenet;
+
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+
+public abstract class SimpleNetTestMessageBase implements IMessage {
+
+}

--- a/src/test/java/cpw/mods/fml/test/simplenet/SimpleNetTester.java
+++ b/src/test/java/cpw/mods/fml/test/simplenet/SimpleNetTester.java
@@ -1,20 +1,39 @@
 package cpw.mods.fml.test.simplenet;
 
 import static org.junit.Assert.*;
+import org.junit.Before;
 import org.junit.Test;
+import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.network.NetworkRegistry;
 import cpw.mods.fml.common.network.simpleimpl.SimpleNetworkWrapper;
 import cpw.mods.fml.relauncher.Side;
 
 public class SimpleNetTester {
 
-    @Test
-    public void test()
+    private static SimpleNetworkWrapper simpleChannel;
+
+    @Before
+    public void setup()
     {
-        SimpleNetworkWrapper simpleChannel = NetworkRegistry.INSTANCE.newSimpleChannel("TEST");
+        simpleChannel = NetworkRegistry.INSTANCE.newSimpleChannel("TEST");
+
         simpleChannel.registerMessage(SimpleNetHandler1.class, SimpleNetTestMessage1.class, 1, Side.SERVER);
         simpleChannel.registerMessage(SimpleNetHandler2.class, SimpleNetTestMessage2.class, 2, Side.CLIENT);
-        assertTrue("Hello", true);
+        simpleChannel.registerMessage(SimpleNetHandlerAny.class, SimpleNetTestMessage1.class, 1, Side.CLIENT);
+        simpleChannel.registerMessage(SimpleNetHandlerAny.class, SimpleNetTestMessage2.class, 2, Side.SERVER);
+    }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void testDuplicateChannelException()
+    {
+        simpleChannel.registerMessage(SimpleNetHandler1.class, SimpleNetTestMessage1.class, 1, Side.SERVER);
+    }
+
+    @Test
+    public void testMessageSending()
+    {
+        simpleChannel.sendToAll(new SimpleNetTestMessage1());
+        simpleChannel.sendToAll(new SimpleNetTestMessage2());
     }
 
 }


### PR DESCRIPTION
This somewhat mimics Netty's implementation of SimpleChannelInboundHandler: 

```
public abstract class SimpleChannelInboundHandler<I> extends ChannelInboundHandlerAdapter {
    ...
    protected SimpleChannelInboundHandler(Class<? extends I> inboundMessageType)
    ...
}
```

I was running the tests at runtime using:

```
JUnitCore.runClasses(SimpleNetTester.class);
```
