### PR TITLE
Remove invisible close buttons from error screens.

### DIFF
--- a/src/main/java/cpw/mods/fml/client/GuiCustomModLoadingErrorScreen.java
+++ b/src/main/java/cpw/mods/fml/client/GuiCustomModLoadingErrorScreen.java
@@ -22,12 +22,13 @@ public class GuiCustomModLoadingErrorScreen extends GuiErrorScreen
         super(null,null);
         this.customException = customException;
     }
+
     @Override
     public void initGui()
     {
-        super.initGui();
         this.customException.initGui(this, fontRendererObj);
     }
+
     @Override
     public void drawScreen(int p_73863_1_, int p_73863_2_, float p_73863_3_)
     {

--- a/src/main/java/cpw/mods/fml/client/GuiDupesFound.java
+++ b/src/main/java/cpw/mods/fml/client/GuiDupesFound.java
@@ -31,10 +31,8 @@ public class GuiDupesFound extends GuiErrorScreen
     }
 
     @Override
-    public void initGui()
-    {
-        super.initGui();
-    }
+    public void initGui() {}
+
     @Override
     public void drawScreen(int p_73863_1_, int p_73863_2_, float p_73863_3_)
     {

--- a/src/main/java/cpw/mods/fml/client/GuiModsMissing.java
+++ b/src/main/java/cpw/mods/fml/client/GuiModsMissing.java
@@ -29,10 +29,8 @@ public class GuiModsMissing extends GuiErrorScreen
     }
 
     @Override
-    public void initGui()
-    {
-        super.initGui();
-    }
+    public void initGui() {}
+
     @Override
     public void drawScreen(int p_73863_1_, int p_73863_2_, float p_73863_3_)
     {

--- a/src/main/java/cpw/mods/fml/client/GuiWrongMinecraft.java
+++ b/src/main/java/cpw/mods/fml/client/GuiWrongMinecraft.java
@@ -24,11 +24,10 @@ public class GuiWrongMinecraft extends GuiErrorScreen
         super(null,null);
         this.wrongMC = wrongMC;
     }
+
     @Override
-    public void initGui()
-    {
-        super.initGui();
-    }
+    public void initGui() {}
+
     @Override
     public void drawScreen(int p_73863_1_, int p_73863_2_, float p_73863_3_)
     {


### PR DESCRIPTION
Various error screens contain hidden close buttons that allow users to get past them, and try to run the game in an errored state.

This prevents these buttons from being created in the first place.
