### PR TITLE
Change assetDir to runDir in default build.gradle

### DIFF
--- a/install/build.gradle
+++ b/install/build.gradle
@@ -23,7 +23,7 @@ archivesBaseName = "modid"
 
 minecraft {
     version = "${version}"
-    assetDir = "eclipse/assets"
+    runDir = "eclipse/assets"
 }
 
 dependencies {


### PR DESCRIPTION
I dont see why we wouldnt change this?
