### PR TITLE
Delay initialization of minecraft commands until after mod pre-init

### DIFF
--- a/patches/minecraft/net/minecraft/command/ServerCommandManager.java.patch
+++ b/patches/minecraft/net/minecraft/command/ServerCommandManager.java.patch
@@ -1,0 +1,20 @@
+--- ../src-base/minecraft/net/minecraft/command/ServerCommandManager.java
++++ ../src-work/minecraft/net/minecraft/command/ServerCommandManager.java
+@@ -39,7 +39,7 @@
+ {
+     private static final String __OBFID = "CL_00000922";
+ 
+-    public ServerCommandManager()
++    public void delayInit()
+     {
+         this.func_71560_a(new CommandTime());
+         this.func_71560_a(new CommandGameMode());
+@@ -96,6 +96,8 @@
+         {
+             this.func_71560_a(new CommandPublishLocalServer());
+         }
++    }
++    public ServerCommandManager(){
+ 
+         CommandBase.func_71529_a(this);
+     }

--- a/src/main/java/cpw/mods/fml/common/FMLCommonHandler.java
+++ b/src/main/java/cpw/mods/fml/common/FMLCommonHandler.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import net.minecraft.command.ServerCommandManager;
 import net.minecraft.crash.CrashReport;
 import net.minecraft.crash.CrashReportCategory;
 import net.minecraft.entity.item.EntityItem;
@@ -312,6 +313,8 @@ public class FMLCommonHandler
     {
         FMLServerHandler.instance();
         sidedDelegate.beginServerLoading(dedicatedServer);
+        ServerCommandManager sch = (ServerCommandManager) dedicatedServer.getCommandManager();
+        sch.delayInit();
     }
 
     public void onServerStarted()


### PR DESCRIPTION
This is a preparation PR to allow some features of https://github.com/MinecraftForge/MinecraftForge/pull/1403

This PR delays the initialization of vanilla's commands, from before FML can startup its hooks into minecraft, to after the mod pre-initialization stage.

This will allow time for permission frameworks as specified in Forge pr 1403 to register themselves in the preinit stage, and thus will be available when the API registers permissions for vanilla commands.
