### PR TITLE
FML's CoreModManager.sortTweakList causes LaunchWrapper to throw CME with Java 8u20

### DIFF
--- a/src/main/java/cpw/mods/fml/relauncher/CoreModManager.java
+++ b/src/main/java/cpw/mods/fml/relauncher/CoreModManager.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Map;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
@@ -533,7 +534,10 @@ public class CoreModManager {
     {
         @SuppressWarnings("unchecked")
         List<ITweaker> tweakers = (List<ITweaker>) Launch.blackboard.get("Tweaks");
-        Collections.sort(tweakers, new Comparator<ITweaker>() {
+
+        // We're not using Collections.sort to avoid CME with Java 8u20 (see issue #501)
+        ITweaker[] tweakersArray = tweakers.toArray(new ITweaker[tweakers.size()]);
+        Arrays.sort(tweakersArray, new Comparator<ITweaker>() {
             @Override
             public int compare(ITweaker o1, ITweaker o2)
             {
@@ -576,6 +580,12 @@ public class CoreModManager {
                 return Ints.saturatedCast((long)first - (long)second);
             }
         });
+
+        ListIterator<ITweaker> it = tweakers.listIterator();
+        for (ITweaker tweaker : tweakersArray) {
+            it.next();
+            it.set(tweaker);
+        }
     }
 
     public static List<String> getAccessTransformers()


### PR DESCRIPTION
Here's full log:

```
[15:39:30] [main/INFO] [FML/]: Forge Mod Loader version 7.10.25.1207 for Minecraft 1.7.10 loading
[15:39:30] [main/INFO] [FML/]: Java is Java HotSpot(TM) 64-Bit Server VM, version 1.8.0_20, running on Windows 8.1:amd64:6.3, installed at C:\Program Files\Java\jre1.8.0_20
[15:39:30] [main/DEBUG] [FML/]: Java classpath at launch is C:\Users\izstas\AppData\Roaming\.minecraft\libraries\net\minecraftforge\forge\1.7.10-10.13.0.1207\forge-1.7.10-10.13.0.1207.jar;C:\Users\izstas\AppData\Roaming\.minecraft\libraries\net\minecraft\launchwrapper\1.11\launchwrapper-1.11.jar;C:\Users\izstas\AppData\Roaming\.minecraft\libraries\org\ow2\asm\asm-all\4.1\asm-all-4.1.jar;C:\Users\izstas\AppData\Roaming\.minecraft\libraries\com\typesafe\akka\akka-actor_2.11\2.3.3\akka-actor_2.11-2.3.3.jar;C:\Users\izstas\AppData\Roaming\.minecraft\libraries\com\typesafe\config\1.2.1\config-1.2.1.jar;C:\Users\izstas\AppData\Roaming\.minecraft\libraries\org\scala-lang\scala-actors-migration_2.11\1.1.0\scala-actors-migration_2.11-1.1.0.jar;C:\Users\izstas\AppData\Roaming\.minecraft\libraries\org\scala-lang\scala-compiler\2.11.1\scala-compiler-2.11.1.jar;C:\Users\izstas\AppData\Roaming\.minecraft\libraries\org\scala-lang\plugins\scala-continuations-library_2.11\1.0.2\scala-continuations-library_2.11-1.0.2.jar;C:\Users\izstas\AppData\Roaming\.minecraft\libraries\org\scala-lang\plugins\scala-continuations-plugin_2.11.1\1.0.2\scala-continuations-plugin_2.11.1-1.0.2.jar;C:\Users\izstas\AppData\Roaming\.minecraft\libraries\org\scala-lang\scala-library\2.11.1\scala-library-2.11.1.jar;C:\Users\izstas\AppData\Roaming\.minecraft\libraries\org\scala-lang\scala-parser-combinators_2.11\1.0.1\scala-parser-combinators_2.11-1.0.1.jar;C:\Users\izstas\AppData\Roaming\.minecraft\libraries\org\scala-lang\scala-reflect\2.11.1\scala-reflect-2.11.1.jar;C:\Users\izstas\AppData\Roaming\.minecraft\libraries\org\scala-lang\scala-swing_2.11\1.0.1\scala-swing_2.11-1.0.1.jar;C:\Users\izstas\AppData\Roaming\.minecraft\libraries\org\scala-lang\scala-xml_2.11\1.0.2\scala-xml_2.11-1.0.2.jar;C:\Users\izstas\AppData\Roaming\.minecraft\libraries\net\sf\jopt-simple\jopt-simple\4.5\jopt-simple-4.5.jar;C:\Users\izstas\AppData\Roaming\.minecraft\libraries\lzma\lzma\0.0.1\lzma-0.0.1.jar;C:\Users\izstas\AppData\Roaming\.minecraft\libraries\com\mojang\realms\1.3.1\realms-1.3.1.jar;C:\Users\izstas\AppData\Roaming\.minecraft\libraries\org\apache\commons\commons-compress\1.8.1\commons-compress-1.8.1.jar;C:\Users\izstas\AppData\Roaming\.minecraft\libraries\org\apache\httpcomponents\httpclient\4.3.3\httpclient-4.3.3.jar;C:\Users\izstas\AppData\Roaming\.minecraft\libraries\commons-logging\commons-logging\1.1.3\commons-logging-1.1.3.jar;C:\Users\izstas\AppData\Roaming\.minecraft\libraries\org\apache\httpcomponents\httpcore\4.3.2\httpcore-4.3.2.jar;C:\Users\izstas\AppData\Roaming\.minecraft\libraries\java3d\vecmath\1.3.1\vecmath-1.3.1.jar;C:\Users\izstas\AppData\Roaming\.minecraft\libraries\net\sf\trove4j\trove4j\3.0.3\trove4j-3.0.3.jar;C:\Users\izstas\AppData\Roaming\.minecraft\libraries\com\ibm\icu\icu4j-core-mojang\51.2\icu4j-core-mojang-51.2.jar;C:\Users\izstas\AppData\Roaming\.minecraft\libraries\com\paulscode\codecjorbis\20101023\codecjorbis-20101023.jar;C:\Users\izstas\AppData\Roaming\.minecraft\libraries\com\paulscode\codecwav\20101023\codecwav-20101023.jar;C:\Users\izstas\AppData\Roaming\.minecraft\libraries\com\paulscode\libraryjavasound\20101123\libraryjavasound-20101123.jar;C:\Users\izstas\AppData\Roaming\.minecraft\libraries\com\paulscode\librarylwjglopenal\20100824\librarylwjglopenal-20100824.jar;C:\Users\izstas\AppData\Roaming\.minecraft\libraries\com\paulscode\soundsystem\20120107\soundsystem-20120107.jar;C:\Users\izstas\AppData\Roaming\.minecraft\libraries\io\netty\netty-all\4.0.10.Final\netty-all-4.0.10.Final.jar;C:\Users\izstas\AppData\Roaming\.minecraft\libraries\com\google\guava\guava\16.0\guava-16.0.jar;C:\Users\izstas\AppData\Roaming\.minecraft\libraries\org\apache\commons\commons-lang3\3.2.1\commons-lang3-3.2.1.jar;C:\Users\izstas\AppData\Roaming\.minecraft\libraries\commons-io\commons-io\2.4\commons-io-2.4.jar;C:\Users\izstas\AppData\Roaming\.minecraft\libraries\commons-codec\commons-codec\1.9\commons-codec-1.9.jar;C:\Users\izstas\AppData\Roaming\.minecraft\libraries\net\java\jinput\jinput\2.0.5\jinput-2.0.5.jar;C:\Users\izstas\AppData\Roaming\.minecraft\libraries\net\java\jutils\jutils\1.0.0\jutils-1.0.0.jar;C:\Users\izstas\AppData\Roaming\.minecraft\libraries\com\google\code\gson\gson\2.2.4\gson-2.2.4.jar;C:\Users\izstas\AppData\Roaming\.minecraft\libraries\com\mojang\authlib\1.5.16\authlib-1.5.16.jar;C:\Users\izstas\AppData\Roaming\.minecraft\libraries\org\apache\logging\log4j\log4j-api\2.0-beta9\log4j-api-2.0-beta9.jar;C:\Users\izstas\AppData\Roaming\.minecraft\libraries\org\apache\logging\log4j\log4j-core\2.0-beta9\log4j-core-2.0-beta9.jar;C:\Users\izstas\AppData\Roaming\.minecraft\libraries\org\lwjgl\lwjgl\lwjgl\2.9.1\lwjgl-2.9.1.jar;C:\Users\izstas\AppData\Roaming\.minecraft\libraries\org\lwjgl\lwjgl\lwjgl_util\2.9.1\lwjgl_util-2.9.1.jar;C:\Users\izstas\AppData\Roaming\.minecraft\libraries\tv\twitch\twitch\5.16\twitch-5.16.jar;C:\Users\izstas\AppData\Roaming\.minecraft\versions\1.7.10-Forge10.13.0.1207\1.7.10-Forge10.13.0.1207.jar
[15:39:30] [main/DEBUG] [FML/]: Java library path at launch is C:\Users\izstas\AppData\Roaming\.minecraft\versions\1.7.10-Forge10.13.0.1207\1.7.10-Forge10.13.0.1207-natives-10562761737958
[15:39:30] [main/DEBUG] [FML/]: Enabling runtime deobfuscation
[15:39:30] [main/DEBUG] [FML/]: Instantiating coremod class FMLCorePlugin
[15:39:30] [main/DEBUG] [FML/]: Added access transformer class cpw.mods.fml.common.asm.transformers.AccessTransformer to enqueued access transformers
[15:39:30] [main/DEBUG] [FML/]: Enqueued coremod FMLCorePlugin
[15:39:30] [main/DEBUG] [FML/]: Instantiating coremod class FMLForgePlugin
[15:39:30] [main/DEBUG] [FML/]: Added access transformer class net.minecraftforge.transformers.ForgeAccessTransformer to enqueued access transformers
[15:39:30] [main/DEBUG] [FML/]: Enqueued coremod FMLForgePlugin
[15:39:30] [main/DEBUG] [FML/]: All fundamental core mods are successfully located
[15:39:30] [main/DEBUG] [FML/]: Discovering coremods
[15:39:30] [main/INFO] [LaunchWrapper/]: Loading tweak class name cpw.mods.fml.common.launcher.FMLInjectionAndSortingTweaker
[15:39:30] [main/INFO] [LaunchWrapper/]: Loading tweak class name cpw.mods.fml.common.launcher.FMLDeobfTweaker
[15:39:30] [main/INFO] [LaunchWrapper/]: Calling tweak class cpw.mods.fml.common.launcher.FMLInjectionAndSortingTweaker
[15:39:30] [main/ERROR] [LaunchWrapper/]: Unable to launch
java.util.ConcurrentModificationException
    at java.util.ArrayList$Itr.checkForComodification(Unknown Source) ~[?:1.8.0_20]
    at java.util.ArrayList$Itr.remove(Unknown Source) ~[?:1.8.0_20]
    at net.minecraft.launchwrapper.Launch.launch(Launch.java:118) [launchwrapper-1.11.jar:?]
    at net.minecraft.launchwrapper.Launch.main(Launch.java:28) [launchwrapper-1.11.jar:?]
```

As I understand, the issue is that now `Collections.sort` delegates to instance method `List.sort`, which increases the `modCount` for `ArrayList`. A possible work around could be porting old `Collections.sort` implementation to FML itself.
