### PR TITLE
Allow client handshake to be reset by server to support BungeeCord.

### DIFF
--- a/src/main/java/cpw/mods/fml/common/network/handshake/FMLHandshakeClientState.java
+++ b/src/main/java/cpw/mods/fml/common/network/handshake/FMLHandshakeClientState.java
@@ -125,6 +125,11 @@ enum FMLHandshakeClientState implements IHandshakeState<FMLHandshakeClientState>
         @Override
         public FMLHandshakeClientState accept(ChannelHandlerContext ctx, FMLHandshakeMessage msg)
         {
+            if (msg instanceof FMLHandshakeMessage.HandshakeReset)
+            {
+                GameData.revertToFrozen();
+                return HELLO;
+            }
             return this;
         }
     },

--- a/src/main/java/cpw/mods/fml/common/network/handshake/FMLHandshakeCodec.java
+++ b/src/main/java/cpw/mods/fml/common/network/handshake/FMLHandshakeCodec.java
@@ -12,6 +12,7 @@ public class FMLHandshakeCodec extends FMLIndexedMessageToMessageCodec<FMLHandsh
         addDiscriminator((byte)2, FMLHandshakeMessage.ModList.class);
         addDiscriminator((byte)3, FMLHandshakeMessage.ModIdData.class);
         addDiscriminator((byte)-1, FMLHandshakeMessage.HandshakeAck.class);
+        addDiscriminator((byte)-2, FMLHandshakeMessage.HandshakeReset.class);
     }
     @Override
     public void encodeInto(ChannelHandlerContext ctx, FMLHandshakeMessage msg, ByteBuf target) throws Exception

--- a/src/main/java/cpw/mods/fml/common/network/handshake/FMLHandshakeMessage.java
+++ b/src/main/java/cpw/mods/fml/common/network/handshake/FMLHandshakeMessage.java
@@ -235,6 +235,9 @@ public abstract class FMLHandshakeMessage {
             return super.toString(side) + ":{"+phase+"}";
         }
     }
+    public static class HandshakeReset extends FMLHandshakeMessage {
+        public HandshakeReset() {}
+    }
     public void fromBytes(ByteBuf buffer)
     {
     }


### PR DESCRIPTION
Added 'FMLHandshakeMessage.HandshakeReset' in order to allow servers, such as BungeeCord, to reset a client's handshake when changing servers. FMLHandshakeClientState will simply listen for this packet in the 'DONE' state and transition to 'HELLO' when it receives it.
