### PR TITLE
Added extra priorities to support Sponge

### DIFF
--- a/src/main/java/cpw/mods/fml/common/eventhandler/EventBus.java
+++ b/src/main/java/cpw/mods/fml/common/eventhandler/EventBus.java
@@ -147,6 +147,10 @@ public class EventBus implements IEventExceptionHandler
         return (event.isCancelable() ? event.isCanceled() : false);
     }
 
+    public int getBusID() {
+        return busID;
+    }
+
     @Override
     public void handleException(EventBus bus, Event event, IEventListener[] listeners, int index, Throwable throwable)
     {

--- a/src/main/java/cpw/mods/fml/common/eventhandler/EventPriority.java
+++ b/src/main/java/cpw/mods/fml/common/eventhandler/EventPriority.java
@@ -8,11 +8,15 @@ public enum EventPriority implements IEventListener
      *   Due to using a ArrayList in the ListenerList,
      *   these need to stay in a contiguous index starting at 0. {Default ordinal}
      */
-    HIGHEST, //First to execute
+    PRE, //First to execute.  Cancellation is not allowed
+    AFTER_PRE, //Cancellation is not allowed
+    HIGHEST, //First standard priority to execute
     HIGH,
     NORMAL,
     LOW,
-    LOWEST //Last to execute
+    LOWEST, //Last standard priority to execute
+    BEFORE_POST, //Cancellation is not allowed
+    POST //Last to execute.  Cancellation is not allowed
 ;
 
     @Override


### PR DESCRIPTION
Sponge has 4 extra priority levels.  This expands the EventPriority enum so that the extra priorities are supported.

It also adds a .getBusID() method to the EventBus class.  This means that the Sponge event system can directly submit events to the ListenerLists associated with Forge events.
