### PR TITLE
Fixed the ModDiscoverer  not inspecting inner classes

### DIFF
--- a/src/main/java/cpw/mods/fml/common/discovery/DirectoryDiscoverer.java
+++ b/src/main/java/cpw/mods/fml/common/discovery/DirectoryDiscoverer.java
@@ -38,7 +38,7 @@ public class DirectoryDiscoverer implements ITypeDiscoverer
         @Override
         public boolean accept(File file)
         {
-            return (file.isFile() && classFile.matcher(file.getName()).find()) || file.isDirectory();
+            return (file.isFile() && classFile.matcher(file.getName()).matches()) || file.isDirectory();
         }
     }
 

--- a/src/main/java/cpw/mods/fml/common/discovery/ITypeDiscoverer.java
+++ b/src/main/java/cpw/mods/fml/common/discovery/ITypeDiscoverer.java
@@ -19,7 +19,7 @@ import cpw.mods.fml.common.ModContainer;
 
 public interface ITypeDiscoverer
 {
-    public static Pattern classFile = Pattern.compile("([^\\s$]+).class$");
+    public static Pattern classFile = Pattern.compile("[^\\s]+\\.class");
 
     public List<ModContainer> discover(ModCandidate candidate, ASMDataTable table);
 }


### PR DESCRIPTION
Fixes inner classes not present in the ASMDataTable. See #511.