### PR TITLE
Fixed broken documentation

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -80,7 +80,7 @@ Standalone source installation
 ==============================
 
 To install this source code for development purposes, extract this zip file.
-It ships with a demonstration mod. Run "gradle setupDevWorkspace" to create
+It ships with a demonstration mod. Run "gradle setupFML" to create
 a gradle environment primed with FML. Run gradle eclipse or gradle idea to
 create an IDE workspace of your choice.
 Refer to ForgeGradle for more information about the gradle environment


### PR DESCRIPTION
I was trying to setup my FML workspace to try and help update Forge, however when trying to setup FML, I ran into some broken documentation.

It says it needs the command "gradle setupDevWorkspace", however when I did, it gave me an error saying that it found no commands by that name in the project "fml".

So in the end, I found out that the correct command was "gradle setupFML" through the command that lists all available commands in the project.

If I'm being stupid, or I'm doing something wrong, please say. And, feel-free to deny this request if you feel it's incorrect.
