### PR TITLE
Fix addSubstitutionAlias in multiplayer

### DIFF
--- a/src/main/java/cpw/mods/fml/common/registry/FMLControlledNamespacedRegistry.java
+++ b/src/main/java/cpw/mods/fml/common/registry/FMLControlledNamespacedRegistry.java
@@ -102,6 +102,8 @@ public class FMLControlledNamespacedRegistry<I> extends RegistryNamespaced {
         {
             addObjectRaw(registry.getId(thing), registry.getNameForObject(thing), thing);
         }
+        activeSubstitutions.clear();
+        activeSubstitutions.putAll(registry.activeSubstitutions);
     }
 
     // public api


### PR DESCRIPTION
The below is the summary of what I discovered reading the code, breaking it a few times, and then coming up with the solution proposed.  I was super happy when I discovered addSubstitutionAlias in FML but was sadly disapointed when it didn't work completely.  So here's my attempt at ironing out the issue.

 Changes to be committed:
    modified:   src/main/java/cpw/mods/fml/common/registry/FMLControlledNamespacedRegistry.java

When injectWorldIDMap() finishes processing changes, getMain().set(newData) is called to syncronize the data to the game world.  The problem is that the set() call in FMLControlledNamespacedRegistry did not syncronize the activeSubstitutions into the namespace.

The result of this allowed the game to syncronize properly with itself locally (so the client and the server would run fine as this data was already locally embedded).   But in multiplayer the registration would desyncronize due to an incorrectly crafted packet.

On the server side, FMLControlledNamespacedRegistry would always pass an empty substitution list during serializeSubstitutions() calls, which results in future GameData.buildItemDataList() call having null activeSubstitution lists.  This causes a problem later as when a client tries to connect, the constructor FMLHandshakeMessage.ModIdData(GameData.GameDataSnapshot) also receives null substitution lists and crafts invalid ModIdData packets.
