### PR TITLE
GuiConfig instance fixes

### DIFF
--- a/src/main/java/cpw/mods/fml/client/GuiModList.java
+++ b/src/main/java/cpw/mods/fml/client/GuiModList.java
@@ -50,7 +50,7 @@ import cpw.mods.fml.common.ModContainer.Disableable;
 public class GuiModList extends GuiScreen
 {
     private GuiScreen mainMenu;
-    private GuiSlotModList modList;
+    private cpw.mods.fml.client.GuiSlotModList modList;
     private int selected = -1;
     private ModContainer selectedMod;
     private int listWidth;
@@ -67,7 +67,7 @@ public class GuiModList extends GuiScreen
     {
         this.mainMenu=mainMenu;
         this.mods=new ArrayList<ModContainer>();
-        FMLClientHandler.instance().addSpecialModEntries(mods);
+        cpw.mods.fml.client.FMLClientHandler.instance().addSpecialModEntries(mods);
         for (ModContainer mod : Loader.instance().getModList()) {
             if (mod.getMetadata()!=null && mod.getMetadata().parentMod==null && !Strings.isNullOrEmpty(mod.getMetadata().parent)) {
                 String parentMod = mod.getMetadata().parent;
@@ -101,7 +101,7 @@ public class GuiModList extends GuiScreen
         disableModButton = new GuiButton(21, 10, this.height - 38, this.listWidth, 20, "Disable");
         this.buttonList.add(configModButton);
         this.buttonList.add(disableModButton);
-        this.modList=new GuiSlotModList(this, mods, listWidth);
+        this.modList=new cpw.mods.fml.client.GuiSlotModList(this, mods, listWidth);
         this.modList.registerScrollButtons(this.buttonList, 7, 8);
     }
 
@@ -118,7 +118,16 @@ public class GuiModList extends GuiScreen
                     try
                     {
                         IModGuiFactory guiFactory = FMLClientHandler.instance().getGuiFactoryFor(selectedMod);
-                        GuiScreen newScreen = guiFactory.getMainConfigGui();
+                        Object screenObj = guiFactory.getMainConfigGui();
+						GuiScreen newScreen = null;
+						
+						if (screenObj instanceof GuiScreen) 
+							newScreen = (GuiScreen) screenObj;
+						else if (screenObj instanceof Class && GuiScreen.class.isAssignableFrom((Class<?>) screenObj))
+							newScreen = ((Class<? extends GuiScreen>)screenObj).getConstructor(GuiScreen.class).newInstance(this);
+						else
+							throw new IllegalStateException("Invalid type for getMainConfigGui");
+							
                         this.mc.displayGuiScreen(newScreen);
                     }
                     catch (Exception e)
@@ -156,7 +165,7 @@ public class GuiModList extends GuiScreen
                 {
                     GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
                     TextureManager tm = mc.getTextureManager();
-                    IResourcePack pack = FMLClientHandler.instance().getResourcePackFor(selectedMod.getModId());
+                    IResourcePack pack = cpw.mods.fml.client.FMLClientHandler.instance().getResourcePackFor(selectedMod.getModId());
                     try
                     {
                         if (cachedLogo == null)
@@ -244,7 +253,7 @@ public class GuiModList extends GuiScreen
                     disableModButton.visible = true;
                     disableModButton.enabled = false;
                 }
-                IModGuiFactory guiFactory = FMLClientHandler.instance().getGuiFactoryFor(selectedMod);
+                cpw.mods.fml.client.IModGuiFactory guiFactory = cpw.mods.fml.client.FMLClientHandler.instance().getGuiFactoryFor(selectedMod);
                 if (guiFactory == null || guiFactory.getMainConfigGui() == null)
                 {
                     configModButton.visible = true;

--- a/src/main/java/cpw/mods/fml/client/IModGuiFactory.java
+++ b/src/main/java/cpw/mods/fml/client/IModGuiFactory.java
@@ -13,9 +13,15 @@ public interface IModGuiFactory {
      * @param minecraftInstance the instance
      */
     public void initialize(Minecraft minecraftInstance);
+	
     /**
-     * Return a new GuiScreen Instance {@link GuiScreen}. This instance is passed
-	 * When the 'config' button is pressed in the GuiModList. 
+     * Return either:
+	 * a) A new instance of GuiScreen
+	 * b) A class object of a GuiScreen
+	 *
+	 * Classes will be instantiated each time the 'config' button is pressed in
+	 * GuiModList, however, instances of GuiScreen will be passed directly.
+	 * 
 	 * The expected behaviour is that this screen will replace the
      * "mod list" screen completely, and will return to the mod list screen through
      * the parent link, once the appropriate action is taken from the config screen.
@@ -32,7 +38,7 @@ public interface IModGuiFactory {
      *
      * @return A new GuiScreen for when the 'config' button is pressed on the GuiModList
      */
-    public GuiScreen getMainConfigGui();
+    public Object getMainConfigGui();
 
 
     /**


### PR DESCRIPTION
Simple fix that changes the mainConfigGuiClass() method in IModGuiFactory to be able to use instances. The advantages being:

-Less overhead (no need to instantiate via reflection)
-More flexible (the instances can be instantiated however the user wishes)

I also made it so the modder can still return a class object if they so wish, however, it is a bit redundant. 
