### PR TITLE
Created access point for guiFactories for external registering.

### DIFF
--- a/src/main/java/cpw/mods/fml/client/FMLClientHandler.java
+++ b/src/main/java/cpw/mods/fml/client/FMLClientHandler.java
@@ -157,7 +157,7 @@ public class FMLClientHandler implements IFMLSidedHandler
 
     private Map<String, IResourcePack> resourcePackMap;
 
-    private BiMap<ModContainer, IModGuiFactory> guiFactories;
+    private BiMap<ModContainer, IModGuiFactory> guiFactories = HashBiMap.create();
 
     private Map<ServerStatusResponse,JsonObject> extraServerListData;
     private Map<ServerData, ExtendedServerListData> serverDataTag;
@@ -302,11 +302,10 @@ public class FMLClientHandler implements IFMLSidedHandler
         // Reload resources
         client.refreshResources();
         RenderingRegistry.instance().loadEntityRenderers((Map<Class<? extends Entity>, Render>)RenderManager.instance.entityRenderMap);
-        guiFactories = HashBiMap.create();
         for (ModContainer mc : Loader.instance().getActiveModList())
         {
             String className = mc.getGuiClassName();
-            if (Strings.isNullOrEmpty(className))
+            if (Strings.isNullOrEmpty(className) || guiFactories.containsKey(mc))
             {
                 continue;
             }
@@ -324,6 +323,14 @@ public class FMLClientHandler implements IFMLSidedHandler
         }
         loading = false;
         client.gameSettings.loadOptions(); //Reload options to load any mod added keybindings.
+    }
+    
+    /**
+     *  This method assumes that all necessary initialization has taken place.
+     */
+    public void registerCustomGuiFactory(ModContainer modContainer, IModGuiFactory guiFactory) {
+        if(!guiFactories.containsKey(modContainer))
+            guiFactories.put(modContainer, guiFactory);
     }
 
     @SuppressWarnings("unused")


### PR DESCRIPTION
It was either this, or an event fired after finishMinecraftLoading() to use it to reflect in and add my own values.

_TLDR at the bottom._

**The reason:**
I've been designing a config annotation system, which some might deem unnecessary, that's fine.  
It can do a lot, and is easily expandable.
I can go into more detail for the annotation system.  
Regardless, if you want to understand more, you can go [here](https://github.com/Jezzadabomb338/OmnisCore/tree/master/common/me/jezza/oc/api/configuration).  
I know that some people dislike the idea of the system for their own reasons, I couldn't care less.  
The point of this edit is that my config system is smart. Smart enough that it should be able to create a default GUI with all of it's knowledge about the mod's configuration needs.

If you need me to go into more detail... 

**TLDR: I need access to register a default GuiFactory for all the mods that use my system.**
