### PR TITLE
Save the mod list of players in their NetworkDispatcher

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/network/handshake/FMLHandshakeServerState.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/handshake/FMLHandshakeServerState.java
@@ -41,11 +41,12 @@ enum FMLHandshakeServerState implements IHandshakeState<FMLHandshakeServerState>
             }
 
             FMLHandshakeMessage.ModList client = (FMLHandshakeMessage.ModList)msg;
+            NetworkDispatcher dispatcher = ctx.channel().attr(NetworkDispatcher.FML_DISPATCHER).get();
+            dispatcher.setModList(client.modList());
             FMLLog.info("Client attempting to join with %d mods : %s", client.modListSize(), client.modListAsString());
             String result = FMLNetworkHandler.checkModList(client, Side.CLIENT);
             if (result != null)
             {
-                NetworkDispatcher dispatcher = ctx.channel().attr(NetworkDispatcher.FML_DISPATCHER).get();
                 dispatcher.rejectHandshake(result);
                 return ERROR;
             }

--- a/src/main/java/net/minecraftforge/fml/common/network/handshake/NetworkDispatcher.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/handshake/NetworkDispatcher.java
@@ -13,8 +13,10 @@ import io.netty.util.concurrent.GenericFutureListener;
 import java.io.IOException;
 import java.net.SocketAddress;
 import java.nio.channels.ClosedChannelException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import org.apache.logging.log4j.Level;
 
@@ -85,6 +87,7 @@ public class NetworkDispatcher extends SimpleChannelInboundHandler<Packet> imple
     private final EmbeddedChannel handshakeChannel;
     private NetHandlerPlayServer serverHandler;
     private INetHandler netHandler;
+    private Map<String,String> modList;
 
     public NetworkDispatcher(NetworkManager manager)
     {
@@ -132,6 +135,11 @@ public class NetworkDispatcher extends SimpleChannelInboundHandler<Packet> imple
             FMLLog.info("Connection received without FML marker, assuming vanilla.");
             this.completeServerSideConnection(ConnectionType.VANILLA);
         }
+    }
+    
+    protected void setModList(Map<String,String> modList)
+    {
+        this.modList = modList;
     }
 
     private void insertIntoChannel()
@@ -244,6 +252,16 @@ public class NetworkDispatcher extends SimpleChannelInboundHandler<Packet> imple
     public INetHandler getNetHandler()
     {
         return netHandler;
+    }
+    
+    /**
+     * The mod list returned by this method is in no way reliable because it is provided by the client
+     * 
+     * @return a map that will contain String keys and values listing all mods and their versions
+     */
+    public Map<String,String> getModList()
+    {
+        return Collections.unmodifiableMap(modList);
     }
 
     @Override


### PR DESCRIPTION
And therefore make it accessible to mods.

I'm not sure whether the NetworkDispatcher is the correct place to save the mod list but there isn't much non vanilla stuff available in the handshake packet.

I also thought about adding a convenience method like getModList(EntityPlayer player) somewhere but i wasn't sure where (ForgeHooks? EntityPlayerMP? NetHandlerPlayServer?)