### PR TITLE
Fixed getEffectiveSide() for Netty Server threads

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/FMLCommonHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/FMLCommonHandler.java
@@ -160,7 +160,7 @@ public class FMLCommonHandler
     public Side getEffectiveSide()
     {
         Thread thr = Thread.currentThread();
-        if ((thr.getName().equals("Server thread")))
+        if (thr.getName().equals("Server thread") || thr.getName().startsWith("Netty Server IO"))
         {
             return Side.SERVER;
         }


### PR DESCRIPTION
The method getEffectiveSide() in FMLCommonHandler that uses thread analysis to determine what thread it is currently executed from would not work with Server threads that handle Netty messages. Server Netty threads have as naming "Netty Server IO #" <x>, and there can be multiple, therefore the .startsWith().
