### PR TITLE
Fix ModDiscoverer mod file regex

### DIFF
--- a/src/main/java/cpw/mods/fml/common/discovery/ModDiscoverer.java
+++ b/src/main/java/cpw/mods/fml/common/discovery/ModDiscoverer.java
@@ -32,7 +32,7 @@ import cpw.mods.fml.relauncher.ModListHelper;
 
 public class ModDiscoverer
 {
-    private static Pattern zipJar = Pattern.compile("(.+)\\.(zip|jar)$",Pattern.CASE_INSENSITIVE);
+    private static Pattern zipJar = Pattern.compile("(.+)\\.(zip|jar)$");
 
     private List<ModCandidate> candidates = Lists.newArrayList();
 

--- a/src/main/java/cpw/mods/fml/common/discovery/ModDiscoverer.java
+++ b/src/main/java/cpw/mods/fml/common/discovery/ModDiscoverer.java
@@ -32,7 +32,7 @@ import cpw.mods.fml.relauncher.ModListHelper;
 
 public class ModDiscoverer
 {
-    private static Pattern zipJar = Pattern.compile("(.+).(zip|jar)$");
+    private static Pattern zipJar = Pattern.compile("(.+)\\.(zip|jar)$",Pattern.CASE_INSENSITIVE);
 
     private List<ModCandidate> candidates = Lists.newArrayList();
 


### PR DESCRIPTION
Before the fix, the pattern would incorrectly match "fakejar", because the dot was not literal.

EDIT: Removed case-insensitivity.