### PR TITLE
Move IMCEvent to after PostInit

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/Loader.java
+++ b/src/main/java/net/minecraftforge/fml/common/Loader.java
@@ -691,9 +691,9 @@ public class Loader
         // Mod controller should be in the initialization state here
         modController.distributeStateMessage(LoaderState.INITIALIZATION);
         modController.transition(LoaderState.POSTINITIALIZATION, false);
-        modController.distributeStateMessage(FMLInterModComms.IMCEvent.class);
         modController.distributeStateMessage(LoaderState.POSTINITIALIZATION);
         modController.transition(LoaderState.AVAILABLE, false);
+        modController.distributeStateMessage(FMLInterModComms.IMCEvent.class);
         modController.distributeStateMessage(LoaderState.AVAILABLE);
         GameData.freezeData();
         FMLLog.info("Forge Mod Loader has successfully loaded %d mod%s", mods.size(), mods.size() == 1 ? "" : "s");


### PR DESCRIPTION
There are many mods who send IMC messages during the PostInit phase. Because of this, mods have to process their IMC messages twice (not all of them again (I think), but they run their `handleIMC`-type method twice). This moves when the IMCEvent is fired to after PostInit and before LoadComplete, so that mods can have just one place to process their IMC messages. This shouldn't break anything; in fact, this should help out in the fact that mods can now process IMC messages that were sent during PostInit automatically. I chose the 1.8 branch because this isn't a bug fix, but if people want this change in 1.7.10, it's not that hard to do.