### PR TITLE
Exclude only log4j2 queue from class loader

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/launcher/FMLServerTweaker.java
+++ b/src/main/java/net/minecraftforge/fml/common/launcher/FMLServerTweaker.java
@@ -13,9 +13,9 @@ public class FMLServerTweaker extends FMLTweaker {
     @Override
     public void injectIntoClassLoader(LaunchClassLoader classLoader)
     {
-        // The mojang packages are excluded so the log4j2 queue is correctly visible from
-        // the obfuscated and deobfuscated parts of the code. Without, the UI won't show anything
-        classLoader.addClassLoaderExclusion("com.mojang.");
+        // The log4j2 queue is excluded so it is correctly visible from the obfuscated
+        // and deobfuscated parts of the code. Without, the UI won't show anything
+        classLoader.addClassLoaderExclusion("com.mojang.util.QueueLogAppender");
         classLoader.addTransformerExclusion("net.minecraftforge.fml.repackage.");
         classLoader.addTransformerExclusion("net.minecraftforge.fml.relauncher.");
         classLoader.addTransformerExclusion("net.minecraftforge.fml.common.asm.transformers.");


### PR DESCRIPTION
Right now the complete `com.mojang.*` package is excluded from the `LaunchClassLoader` on the server. This means mods can't transform `authlib` for example which doesn't need to be excluded for the UI to work. By excluding only the specific log4j2 `QueueLogAppender`, mods can also transform the classes in the `com.mojang.authlib` package.

Specifically we want to use this in the Sponge mod to implement our [`GameProfile` interface](https://github.com/SpongePowered/SpongeAPI/blob/master/src/main/java/org/spongepowered/api/GameProfile.java) into Mojang's `GameProfile` class (`com.mojang.authlib.GameProfile`). This isn't possible right now because the class is excluded from the `LaunchClassLoader` and can't be transformed because of that.

I have tested that the UI is still printing the log correctly using this change.