### PR TITLE
Provide fallback for empty languagelist causing NPE

### DIFF
--- a/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
+++ b/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
@@ -594,7 +594,7 @@ public class FMLClientHandler implements IFMLSidedHandler
     @Override
     public String getCurrentLanguage()
     {
-        return client.getLanguageManager().getCurrentLanguage().getLanguageCode();
+        return (client.getLangaugeManager().getCurrentLanguage() == null) ? "en_US" : client.getLanguageManager().getCurrentLanguage().getLanguageCode();
     }
 
     @Override


### PR DESCRIPTION
`LanguageRegistry.instance().getStringLocalization(name)` will cause an null pointer exception if the language list is empty (which it is in the default deobf environment)
