### PR TITLE
Update to ASM5 for Java 8 support

### DIFF
--- a/src/main/java/cpw/mods/fml/common/asm/transformers/EventSubscriptionTransformer.java
+++ b/src/main/java/cpw/mods/fml/common/asm/transformers/EventSubscriptionTransformer.java
@@ -8,7 +8,7 @@ import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
 import static org.objectweb.asm.Opcodes.ACC_STATIC;
 import static org.objectweb.asm.Opcodes.ALOAD;
 import static org.objectweb.asm.Opcodes.ARETURN;
-import static org.objectweb.asm.Opcodes.ASM4;
+import static org.objectweb.asm.Opcodes.ASM5;
 import static org.objectweb.asm.Opcodes.DUP;
 import static org.objectweb.asm.Opcodes.F_SAME;
 import static org.objectweb.asm.Opcodes.GETSTATIC;
@@ -139,7 +139,7 @@ public class EventSubscriptionTransformer implements IClassTransformer
          *              super();
          *      }
          */
-        MethodNode method = new MethodNode(ASM4, ACC_PUBLIC, "<init>", getMethodDescriptor(VOID_TYPE), null, null);
+        MethodNode method = new MethodNode(ASM5, ACC_PUBLIC, "<init>", getMethodDescriptor(VOID_TYPE), null, null);
         method.instructions.add(new VarInsnNode(ALOAD, 0));
         method.instructions.add(new MethodInsnNode(INVOKESPECIAL, tSuper.getInternalName(), "<init>", getMethodDescriptor(VOID_TYPE), false));
         method.instructions.add(new InsnNode(RETURN));
@@ -159,7 +159,7 @@ public class EventSubscriptionTransformer implements IClassTransformer
          *              LISTENER_LIST = new ListenerList(super.getListenerList());
          *      }
          */
-        method = new MethodNode(ASM4, ACC_PROTECTED, "setup", getMethodDescriptor(VOID_TYPE), null, null);
+        method = new MethodNode(ASM5, ACC_PROTECTED, "setup", getMethodDescriptor(VOID_TYPE), null, null);
         method.instructions.add(new VarInsnNode(ALOAD, 0));
         method.instructions.add(new MethodInsnNode(INVOKESPECIAL, tSuper.getInternalName(), "setup", getMethodDescriptor(VOID_TYPE), false));
         method.instructions.add(new FieldInsnNode(GETSTATIC, classNode.name, "LISTENER_LIST", tList.getDescriptor()));
@@ -183,7 +183,7 @@ public class EventSubscriptionTransformer implements IClassTransformer
          *              return this.LISTENER_LIST;
          *      }
          */
-        method = new MethodNode(ASM4, ACC_PUBLIC, "getListenerList", getMethodDescriptor(tList), null, null);
+        method = new MethodNode(ASM5, ACC_PUBLIC, "getListenerList", getMethodDescriptor(tList), null, null);
         method.instructions.add(new FieldInsnNode(GETSTATIC, classNode.name, "LISTENER_LIST", tList.getDescriptor()));
         method.instructions.add(new InsnNode(ARETURN));
         classNode.methods.add(method);

--- a/src/main/java/cpw/mods/fml/common/asm/transformers/TerminalTransformer.java
+++ b/src/main/java/cpw/mods/fml/common/asm/transformers/TerminalTransformer.java
@@ -29,7 +29,7 @@ public class TerminalTransformer implements IClassTransformer
 
         private ExitVisitor(ClassVisitor cv)
         {
-            super(Opcodes.ASM4, cv);
+            super(Opcodes.ASM5, cv);
         }
 
         @Override
@@ -49,7 +49,7 @@ public class TerminalTransformer implements IClassTransformer
                                    clsName.startsWith("scala/sys/")
                                    );
 
-            return new MethodVisitor(Opcodes.ASM4, super.visitMethod(mAccess, mName, mDesc, mSignature, mExceptions))
+            return new MethodVisitor(Opcodes.ASM5, super.visitMethod(mAccess, mName, mDesc, mSignature, mExceptions))
             {
                 @Override
                 public void visitMethodInsn(int opcode, String owner, String name, String desc, boolean isIntf)

--- a/src/main/java/cpw/mods/fml/common/discovery/asm/ModAnnotationVisitor.java
+++ b/src/main/java/cpw/mods/fml/common/discovery/asm/ModAnnotationVisitor.java
@@ -25,7 +25,7 @@ public class ModAnnotationVisitor extends AnnotationVisitor
 
     public ModAnnotationVisitor(ASMModParser discoverer)
     {
-        super(Opcodes.ASM4);
+        super(Opcodes.ASM5);
         this.discoverer = discoverer;
     }
 

--- a/src/main/java/cpw/mods/fml/common/discovery/asm/ModClassVisitor.java
+++ b/src/main/java/cpw/mods/fml/common/discovery/asm/ModClassVisitor.java
@@ -24,7 +24,7 @@ public class ModClassVisitor extends ClassVisitor
 
     public ModClassVisitor(ASMModParser discoverer)
     {
-        super(Opcodes.ASM4);
+        super(Opcodes.ASM5);
         this.discoverer = discoverer;
     }
 

--- a/src/main/java/cpw/mods/fml/common/discovery/asm/ModFieldVisitor.java
+++ b/src/main/java/cpw/mods/fml/common/discovery/asm/ModFieldVisitor.java
@@ -24,7 +24,7 @@ public class ModFieldVisitor extends FieldVisitor
 
     public ModFieldVisitor(String name, ASMModParser discoverer)
     {
-        super(Opcodes.ASM4);
+        super(Opcodes.ASM5);
         this.fieldName = name;
         this.discoverer = discoverer;
     }

--- a/src/main/java/cpw/mods/fml/common/discovery/asm/ModMethodVisitor.java
+++ b/src/main/java/cpw/mods/fml/common/discovery/asm/ModMethodVisitor.java
@@ -12,7 +12,7 @@ public class ModMethodVisitor extends MethodVisitor {
 
     public ModMethodVisitor(String name, String desc, ASMModParser discoverer)
     {
-        super(Opcodes.ASM4);
+        super(Opcodes.ASM5);
         this.methodName = name;
         this.methodDescriptor = desc;
         this.discoverer = discoverer;


### PR DESCRIPTION
SpecialSource updated ASM5 and ForgeGradle supports ASM5 as well but neither FML or Forge were actually updated to support ASM5 opcodes. This commit resolves this.

Signed-off-by: Steven Downer <grinch@outlook.com>