### PR TITLE
Print "Done" on the server after ServerStarting was fired

### DIFF
--- a/patches/minecraft/net/minecraft/server/dedicated/DedicatedServer.java.patch
+++ b/patches/minecraft/net/minecraft/server/dedicated/DedicatedServer.java.patch
@@ -25,20 +25,28 @@
                  this.func_152361_a(new DedicatedPlayerList(this));
                  long j = System.nanoTime();
  
-@@ -250,6 +254,7 @@
+@@ -250,11 +254,9 @@
                  this.func_71191_d((this.func_71207_Z() + 8) / 16 * 16);
                  this.func_71191_d(MathHelper.func_76125_a(this.func_71207_Z(), 64, 256));
                  this.field_71340_o.func_73667_a("max-build-height", Integer.valueOf(this.func_71207_Z()));
 +                if (!net.minecraftforge.fml.common.FMLCommonHandler.instance().handleServerAboutToStart(this)) return false;
                  field_155771_h.info("Preparing level \"" + this.func_71270_I() + "\"");
                  this.func_71247_a(this.func_71270_I(), this.func_71270_I(), k, worldtype, s2);
-                 long i1 = System.nanoTime() - j;
-@@ -278,7 +283,7 @@
+-                long i1 = System.nanoTime() - j;
+-                String s3 = String.format("%.3fs", new Object[] {Double.valueOf((double)i1 / 1.0E9D)});
+-                field_155771_h.info("Done (" + s3 + ")! For help, type \"help\" or \"?\"");
+ 
+                 if (this.field_71340_o.func_73670_a("enable-query", false))
+                 {
+@@ -278,6 +280,11 @@
                      thread1.start();
                  }
  
--                return true;
-+                return net.minecraftforge.fml.common.FMLCommonHandler.instance().handleServerStarting(this);
++                if (!net.minecraftforge.fml.common.FMLCommonHandler.instance().handleServerStarting(this)) return false;
++
++                long i1 = System.nanoTime() - j;
++                String s3 = String.format("%.3fs", new Object[] {Double.valueOf((double)i1 / 1.0E9D)});
++                field_155771_h.info("Done (" + s3 + ")! For help, type \"help\" or \"?\"");
+                 return true;
              }
          }
-     }


### PR DESCRIPTION
When mods take some time to load something when FML fires server starting on the dedicated server it will print "Done" before this right now. This will make the user think that the server is ready, although it's actually still loading. This moves the message after the event was called, so the time is correctly displayed and the message will be printed after mods have handled the event.