### PR TITLE
Handle empty lines in language files gracefully

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/FMLCommonHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/FMLCommonHandler.java
@@ -736,7 +736,7 @@ public class FMLCommonHandler
         boolean isEnhanced = false;
         for (String line : IOUtils.readLines(new ByteArrayInputStream(data), Charsets.UTF_8))
         {
-            if (line.charAt(0) == '#')
+            if (!line.isEmpty() && line.charAt(0) == '#')
             {
                 line = line.substring(1).trim();
                 if (line.equals("PARSE_ESCAPES"))


### PR DESCRIPTION
`readLine` can be empty, causing [this crash](http://www.minecraftforge.net/forum/index.php/topic,27788.0.html).