### PR TITLE
Improve mod list GUI, adds sort buttons and a search bar

### DIFF
--- a/src/main/java/net/minecraftforge/fml/client/GuiScrollingList.java
+++ b/src/main/java/net/minecraftforge/fml/client/GuiScrollingList.java
@@ -31,7 +31,7 @@ public abstract class GuiScrollingList
     protected final int listHeight;
     protected final int top;
     protected final int bottom;
-    private final int right;
+    protected final int right;
     protected final int left;
     protected final int slotHeight;
     private int scrollUpActionId;
@@ -41,7 +41,7 @@ public abstract class GuiScrollingList
     private float initialMouseClickY = -2.0F;
     private float scrollFactor;
     private float scrollDistance;
-    private int selectedIndex = -1;
+    protected int selectedIndex = -1;
     private long lastClickTime = 0L;
     private boolean field_25123_p = true;
     private boolean field_27262_q;

--- a/src/main/java/net/minecraftforge/fml/client/GuiSlotModList.java
+++ b/src/main/java/net/minecraftforge/fml/client/GuiSlotModList.java
@@ -16,8 +16,8 @@ import java.util.ArrayList;
 
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraftforge.fml.common.Loader;
-import net.minecraftforge.fml.common.ModContainer;
 import net.minecraftforge.fml.common.LoaderState.ModState;
+import net.minecraftforge.fml.common.ModContainer;
 
 /**
  * @author cpw
@@ -30,7 +30,7 @@ public class GuiSlotModList extends GuiScrollingList
 
     public GuiSlotModList(GuiModList parent, ArrayList<ModContainer> mods, int listWidth)
     {
-        super(parent.getMinecraftInstance(), listWidth, parent.height, 32, parent.height - 66 + 4, 10, 35);
+        super(parent.getMinecraftInstance(), listWidth, parent.height, 32, parent.height - 88 + 4, 10, 35);
         this.parent=parent;
         this.mods=mods;
     }
@@ -63,6 +63,11 @@ public class GuiSlotModList extends GuiScrollingList
     protected int getContentHeight()
     {
         return (this.getSize()) * 35 + 1;
+    }
+    
+    ArrayList<ModContainer> getMods()
+    {
+        return mods;
     }
 
     @Override

--- a/src/main/resources/assets/fml/lang/en_US.lang
+++ b/src/main/resources/assets/fml/lang/en_US.lang
@@ -82,4 +82,6 @@ fml.configgui.tooltip.default=[default: %s]
 fml.configgui.tooltip.defaultNumeric=[range: %s ~ %s, default: %s]
 
 fml.menu.mods=Mods
+fml.menu.mods.normal=Normal
+fml.menu.mods.search=Search:
 fml.menu.modoptions=Mod Options...


### PR DESCRIPTION
This makes the mod list GUI much easier to use, as you can sort alphabetically (or reverse alphabetically) and search by name.

Here's a screenshot of what the new GUI looks like, there are minimal changes to the existing layout other than some minor shifting of the buttons to fit in the search bar:
![](http://puu.sh/gxaDg.png)

