### PR TITLE
Fix ModDiscoverer ignoring inner classes.

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/discovery/DirectoryDiscoverer.java
+++ b/src/main/java/net/minecraftforge/fml/common/discovery/DirectoryDiscoverer.java
@@ -38,7 +38,7 @@ public class DirectoryDiscoverer implements ITypeDiscoverer
         @Override
         public boolean accept(File file)
         {
-            return (file.isFile() && classFile.matcher(file.getName()).find()) || file.isDirectory();
+            return (file.isFile() && classFile.matcher(file.getName()).matches()) || file.isDirectory();
         }
     }
 

--- a/src/main/java/net/minecraftforge/fml/common/discovery/ITypeDiscoverer.java
+++ b/src/main/java/net/minecraftforge/fml/common/discovery/ITypeDiscoverer.java
@@ -19,7 +19,7 @@ import net.minecraftforge.fml.common.ModContainer;
 
 public interface ITypeDiscoverer
 {
-    public static Pattern classFile = Pattern.compile("([^\\s$]+).class$");
+    public static Pattern classFile = Pattern.compile("[^\\s]+\\.class$");
 
     public List<ModContainer> discover(ModCandidate candidate, ASMDataTable table);
 }


### PR DESCRIPTION
This means that `@Mod` and the `ASMDataTable` now work on inner classes.
Updated version of #522 for current master. Fixes #511.