### PR TITLE
Search for coremods in additional mods

### DIFF
--- a/src/main/java/net/minecraftforge/fml/relauncher/CoreModManager.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/CoreModManager.java
@@ -276,7 +276,7 @@ public class CoreModManager {
             coreModList = ObjectArrays.concat(coreModList, versionedCoreMods, File.class);
         }
 
-        ObjectArrays.concat(coreModList, ModListHelper.additionalMods.values().toArray(new File[0]), File.class);
+        coreModList = ObjectArrays.concat(coreModList, ModListHelper.additionalMods.values().toArray(new File[0]), File.class);
 
         coreModList = FileListHelper.sortFileList(coreModList);
 


### PR DESCRIPTION
Fixes additional mods defined via --mods or --modListFile launch args not being searched for coremods.
Resolves #560