### PR TITLE
Catch possible exceptions thrown when reading/writing usercache file

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -78,7 +78,7 @@
          try
          {
              Display.setVSyncEnabled(this.field_71474_y.field_74352_v);
-@@ -971,9 +980,11 @@
+@@ -970,9 +979,11 @@
  
          if (!this.field_71454_w)
          {
@@ -90,7 +90,7 @@
          }
  
          GL11.glFlush();
-@@ -1555,6 +1566,8 @@
+@@ -1554,6 +1565,8 @@
              --this.field_71467_ac;
          }
  
@@ -99,7 +99,7 @@
          this.field_71424_I.func_76320_a("gui");
  
          if (!this.field_71445_n)
-@@ -1699,6 +1712,7 @@
+@@ -1698,6 +1711,7 @@
                          this.field_71462_r.func_146274_d();
                      }
                  }
@@ -107,7 +107,7 @@
              }
  
              if (this.field_71429_W > 0)
-@@ -1836,6 +1850,7 @@
+@@ -1835,6 +1849,7 @@
                          }
                      }
                  }
@@ -115,7 +115,7 @@
              }
  
              for (j = 0; j < 9; ++j)
-@@ -2026,12 +2041,15 @@
+@@ -2025,12 +2040,15 @@
              this.field_71453_ak.func_74428_b();
          }
  
@@ -131,7 +131,7 @@
          this.func_71403_a((WorldClient)null);
          System.gc();
          ISaveHandler isavehandler = this.field_71469_aa.func_75804_a(p_71371_1_, false);
-@@ -2067,6 +2085,12 @@
+@@ -2066,6 +2084,12 @@
  
          while (!this.field_71437_Z.func_71200_ad())
          {
@@ -144,7 +144,7 @@
              String s2 = this.field_71437_Z.func_71195_b_();
  
              if (s2 != null)
-@@ -2142,6 +2166,7 @@
+@@ -2141,6 +2165,7 @@
              this.field_110448_aq.func_148529_f();
              this.func_71351_a((ServerData)null);
              this.field_71455_al = false;

--- a/patches/minecraft/net/minecraft/server/management/PlayerProfileCache.java.patch
+++ b/patches/minecraft/net/minecraft/server/management/PlayerProfileCache.java.patch
@@ -1,0 +1,18 @@
+--- ../src-base/minecraft/net/minecraft/server/management/PlayerProfileCache.java
++++ ../src-work/minecraft/net/minecraft/server/management/PlayerProfileCache.java
+@@ -236,6 +236,7 @@
+             {
+                 ;
+             }
++            catch (Exception exception) { this.field_152665_g.delete(); }
+             finally
+             {
+                 IOUtils.closeQuietly(bufferedreader);
+@@ -289,6 +290,7 @@
+         {
+             return;
+         }
++        catch (Exception exception) {}
+         finally
+         {
+             IOUtils.closeQuietly(bufferedwriter);


### PR DESCRIPTION
As described on #619, this would prevent any possible corruptions to the usercache.json file to crash the game.
If an exception is thrown when writing the file it is silently ignored.
If an exception is thrown when reading the file, the file is deleted and the exception is silently ignored.

(Not sure why there's changes to Minecraft.java.patch, I didn't touch it at any moment, but it showed up when I generated the patches so I thought I should commit it just in case I'd be breaking something by not doing so)