### PR TITLE
Made ExampleMod serverside.

### DIFF
--- a/install/src/main/java/com/example/examplemod/ExampleMod.java
+++ b/install/src/main/java/com/example/examplemod/ExampleMod.java
@@ -5,7 +5,7 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 
-@Mod(modid = ExampleMod.MODID, version = ExampleMod.VERSION)
+@Mod(modid = ExampleMod.MODID, version = ExampleMod.VERSION, acceptableRemoteVersions = "*")
 public class ExampleMod
 {
     public static final String MODID = "examplemod";


### PR DESCRIPTION
ExampleMod originally makes it impossible to join a dev environment server with a normal Forge client.
