### PR TITLE
Stop IllegalFormatConversionException thrown 

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/FMLModContainer.java
+++ b/src/main/java/net/minecraftforge/fml/common/FMLModContainer.java
@@ -632,13 +632,13 @@ public class FMLModContainer implements ModContainer
 
         if (clientSideOnly && side != Side.CLIENT)
         {
-            FMLLog.info("Disabling mod %d it is client side only.", getModId());
+            FMLLog.info("Disabling mod %s it is client side only.", getModId());
             return false;
         }
 
         if (serverSideOnly && side != Side.SERVER)
         {
-            FMLLog.info("Disabling mod %d it is server side only.", getModId());
+            FMLLog.info("Disabling mod %s it is server side only.", getModId());
             return false;
         }
 


### PR DESCRIPTION
When @Mod has flagged client-only or server-only.

%d is not a valid format for getModId(), which returns String.