### PR TITLE
Allow registering custom language adapters.

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/FMLModContainer.java
+++ b/src/main/java/net/minecraftforge/fml/common/FMLModContainer.java
@@ -95,7 +95,24 @@ public class FMLModContainer implements ModContainer
         this.candidate = container;
         this.descriptor = modDescriptor;
         this.modLanguage = (String) modDescriptor.get("modLanguage");
-        this.languageAdapter = "scala".equals(modLanguage) ? new ILanguageAdapter.ScalaAdapter() : new ILanguageAdapter.JavaAdapter();
+        if (!modDescriptor.get("modLanguageAdapter").equals(""))
+        {
+            try
+            {
+                this.languageAdapter = (ILanguageAdapter)Class.forName((String)modDescriptor.get("modLanguageAdapter")).newInstance();
+                FMLLog.finer("Using custom adapter %s (for %s)", this.languageAdapter, this.className);
+            }
+            catch (Exception ex)
+            {
+                FMLLog.severe("Error constructing mod container %s: %s", this.className, ex);
+                FMLCommonHandler.instance().exitJava(1, true);
+            }
+        }
+        else
+        {
+            this.languageAdapter = "scala".equals(modLanguage) ? new ILanguageAdapter.ScalaAdapter() : new ILanguageAdapter.JavaAdapter();
+        }
+
         this.eventMethods = ArrayListMultimap.create();
     }
 

--- a/src/main/java/net/minecraftforge/fml/common/Mod.java
+++ b/src/main/java/net/minecraftforge/fml/common/Mod.java
@@ -157,6 +157,18 @@ public @interface Mod
      * @return The language the mod is authored in
      */
     String modLanguage() default "java";
+    
+    /**
+     * The language adapter to be used to load this mod. This overrides the value of modLanguage. The class must have a
+     * public zero variable constructor and implement {@link ILanguageAdapter} just like the Java and Scala adapters.
+     * 
+     * A class with an invalid constructor or that doesn't implement {@link ILanguageAdapter} will throw an exception and
+     * halt loading.
+     * 
+     * @return The full class name of the language adapter
+     */
+    String modLanguageAdapter() default "";
+    
     /**
      * NOT YET IMPLEMENTED. </br>
      * An optional ASM hook class, that can be used to apply ASM to classes loaded from this mod. It is also given


### PR DESCRIPTION
Allows external mods/library jars to provide language adapters for languages not supported in native Forge.

This would save Forge the maintenance effort of any extra languages people want to load (see #633).