### PR TITLE
(Fixed) Allow registering custom language adapters.

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/FMLModContainer.java
+++ b/src/main/java/net/minecraftforge/fml/common/FMLModContainer.java
@@ -94,9 +94,26 @@ public class FMLModContainer implements ModContainer
         this.source = container.getModContainer();
         this.candidate = container;
         this.descriptor = modDescriptor;
-        this.modLanguage = (String) modDescriptor.get("modLanguage");
-        this.languageAdapter = "scala".equals(modLanguage) ? new ILanguageAdapter.ScalaAdapter() : new ILanguageAdapter.JavaAdapter();
         this.eventMethods = ArrayListMultimap.create();
+        
+        this.modLanguage = (String) modDescriptor.get("modLanguage");
+        if (modDescriptor.get("modLanguageAdapter").equals(""))
+        {
+            this.languageAdapter = "scala".equals(modLanguage) ? new ILanguageAdapter.ScalaAdapter() : new ILanguageAdapter.JavaAdapter();
+        }
+        else
+        {
+            try
+            {
+                this.languageAdapter = (ILanguageAdapter)Class.forName((String)modDescriptor.get("modLanguageAdapter"), true, Loader.instance().getModClassLoader()).newInstance();
+                FMLLog.finer("Using custom language adapter %s (for %s)", this.languageAdapter, this.className);
+            }
+            catch (Exception ex)
+            {
+                FMLLog.severe("Error constructing custom mod language adapter %s (referenced by %s): %s", modDescriptor.get("modLanguageAdapter"), this.className, ex);
+                FMLCommonHandler.instance().exitJava(1, true);
+            }
+        }
     }
 
     private ILanguageAdapter getLanguageAdapter()

--- a/src/main/java/net/minecraftforge/fml/common/Mod.java
+++ b/src/main/java/net/minecraftforge/fml/common/Mod.java
@@ -157,6 +157,18 @@ public @interface Mod
      * @return The language the mod is authored in
      */
     String modLanguage() default "java";
+    
+    /**
+     * The language adapter to be used to load this mod. This overrides the value of modLanguage. The class must have a
+     * public zero variable constructor and implement {@link ILanguageAdapter} just like the Java and Scala adapters.
+     * 
+     * A class with an invalid constructor or that doesn't implement {@link ILanguageAdapter} will throw an exception and
+     * halt loading.
+     * 
+     * @return The full class name of the language adapter
+     */
+    String modLanguageAdapter() default "";
+    
     /**
      * NOT YET IMPLEMENTED. </br>
      * An optional ASM hook class, that can be used to apply ASM to classes loaded from this mod. It is also given


### PR DESCRIPTION
See #634 for the original version of this PR and the blurb.

This version is cleaned up and uses the correct ClassLoader.