### PR TITLE
Detect all mods at the same time

### DIFF
--- a/src/main/java/cpw/mods/fml/common/Loader.java
+++ b/src/main/java/cpw/mods/fml/common/Loader.java
@@ -46,6 +46,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.Multiset.Entry;
 import com.google.common.collect.Multisets;
+import com.google.common.collect.ObjectArrays;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.SetMultimap;
 import com.google.common.collect.Sets;
@@ -338,13 +339,14 @@ public class Loader
         FMLLog.fine("Minecraft jar mods loaded successfully");
 
         FMLLog.info("Searching %s for mods", canonicalModsDir.getAbsolutePath());
-        discoverer.findModDirMods(canonicalModsDir);
+        File[] modsDirs = { canonicalModsDir };
         File versionSpecificModsDir = new File(canonicalModsDir,mccversion);
         if (versionSpecificModsDir.isDirectory())
         {
             FMLLog.info("Also searching %s for mods", versionSpecificModsDir);
-            discoverer.findModDirMods(versionSpecificModsDir);
+            modsDirs = ObjectArrays.concat(modsDirs, versionSpecificModsDir);
         }
+        discoverer.findModDirMods(modsDirs);
 
         mods.addAll(discoverer.identifyMods());
         identifyDuplicates(mods);

--- a/src/main/java/cpw/mods/fml/common/discovery/ModDiscoverer.java
+++ b/src/main/java/cpw/mods/fml/common/discovery/ModDiscoverer.java
@@ -82,10 +82,17 @@ public class ModDiscoverer
 
     }
 
-    public void findModDirMods(File modsDir)
+    public void findModDirMods(File... dirs)
     {
-        File[] modList = FileListHelper.sortFileList(modsDir, null);
-        modList = FileListHelper.sortFileList(ObjectArrays.concat(modList, ModListHelper.additionalMods.values().toArray(new File[0]), File.class));
+        List<File> mods = Lists.newArrayList(ModListHelper.additionalMods.values());
+        for (File dir : dirs)
+        {
+            if (dir != null && dir.exists())
+            {
+                mods.addAll(Lists.newArrayList(dir.listFiles()));
+            }
+        }
+        File[] modList = FileListHelper.sortFileList(mods.toArray(new File[0]));
 
         for (File modFile : modList)
         {


### PR DESCRIPTION
Instead of doing it one folder at a time, do it all at once just like coremods are.
Fixes extra mods being added twice