### PR TITLE
Add classloader exclusion for ASM

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/launcher/FMLServerTweaker.java
+++ b/src/main/java/net/minecraftforge/fml/common/launcher/FMLServerTweaker.java
@@ -16,6 +16,7 @@ public class FMLServerTweaker extends FMLTweaker {
         // The log4j2 queue is excluded so it is correctly visible from the obfuscated
         // and deobfuscated parts of the code. Without, the UI won't show anything
         classLoader.addClassLoaderExclusion("com.mojang.util.QueueLogAppender");
+        classLoader.addClassLoaderExclusion("org.objectweb.asm.");
         classLoader.addTransformerExclusion("net.minecraftforge.fml.repackage.");
         classLoader.addTransformerExclusion("net.minecraftforge.fml.relauncher.");
         classLoader.addTransformerExclusion("net.minecraftforge.fml.common.asm.transformers.");

--- a/src/main/java/net/minecraftforge/fml/common/launcher/FMLTweaker.java
+++ b/src/main/java/net/minecraftforge/fml/common/launcher/FMLTweaker.java
@@ -118,6 +118,7 @@ public class FMLTweaker implements ITweaker {
     {
         classLoader.addClassLoaderExclusion("org.apache.");
         classLoader.addClassLoaderExclusion("com.google.common.");
+        classLoader.addClassLoaderExclusion("org.objectweb.asm.");
         classLoader.addTransformerExclusion("net.minecraftforge.fml.repackage.");
         classLoader.addTransformerExclusion("net.minecraftforge.fml.relauncher.");
         classLoader.addTransformerExclusion("net.minecraftforge.fml.common.asm.transformers.");


### PR DESCRIPTION
This PR excludes ASM from the LaunchClassLoader in order to ensure maximum compatibility between the Mixin framework used by the Sponge Project, and FML coremods.

This also fixes issues encountered in ForgeEssentials/ForgeEssentialsMain#1449.

I have spoken with @mumfrey regarding this, and he has [thus encouraged me](https://github.com/SpongePowered/Mixin/issues/39#issuecomment-93729541) to make this PR.

This PR targets Minecraft 1.8, and I have also prepared a corresponding PR for 1.7.10, #650.