### PR TITLE
dev-time deobf, and removal of unnecessary generated resources at dev-time

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/Loader.java
+++ b/src/main/java/net/minecraftforge/fml/common/Loader.java
@@ -54,6 +54,7 @@ import com.google.common.base.CharMatcher;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
@@ -180,7 +181,7 @@ public class Loader
     private Loader()
     {
         modClassLoader = new ModClassLoader(getClass().getClassLoader());
-        if (!mccversion.equals(MC_VERSION))
+        if (!mccversion.equals(MC_VERSION) && Strings.isNullOrEmpty(System.getProperty("net.minecraftforge.gradle.GradleStart.srg.srg-mcp")))
         {
             FMLLog.severe("This version of FML is built for Minecraft %s, we have detected Minecraft %s in your minecraft jar file", mccversion, MC_VERSION);
             throw new LoaderException(String.format("This version of FML is built for Minecraft %s, we have detected Minecraft %s in your minecraft jar file", mccversion, MC_VERSION));

--- a/src/main/java/net/minecraftforge/fml/common/asm/transformers/DeobfuscationTransformer.java
+++ b/src/main/java/net/minecraftforge/fml/common/asm/transformers/DeobfuscationTransformer.java
@@ -31,7 +31,7 @@ public class DeobfuscationTransformer implements IClassTransformer, IClassNameTr
             return null;
         }
         ClassReader classReader = new ClassReader(bytes);
-        ClassWriter classWriter = new ClassWriter(ClassWriter.COMPUTE_MAXS);
+        ClassWriter classWriter = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
         RemappingClassAdapter remapAdapter = new FMLRemappingAdapter(classWriter);
         classReader.accept(remapAdapter, ClassReader.EXPAND_FRAMES);
         return classWriter.toByteArray();

--- a/src/main/java/net/minecraftforge/fml/common/asm/transformers/deobf/FMLDeobfuscatingRemapper.java
+++ b/src/main/java/net/minecraftforge/fml/common/asm/transformers/deobf/FMLDeobfuscatingRemapper.java
@@ -45,6 +45,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.io.CharSource;
+import com.google.common.io.Files;
 
 public class FMLDeobfuscatingRemapper extends Remapper {
     public static final FMLDeobfuscatingRemapper INSTANCE = new FMLDeobfuscatingRemapper();
@@ -113,10 +114,22 @@ public class FMLDeobfuscatingRemapper extends Remapper {
         this.classLoader = classLoader;
         try
         {
-            InputStream classData = getClass().getResourceAsStream(deobfFileName);
-            LZMAInputSupplier zis = new LZMAInputSupplier(classData);
-            CharSource srgSource = zis.asCharSource(Charsets.UTF_8);
-            List<String> srgList = srgSource.readLines();
+            List<String> srgList;
+            final String gradleStartProp = System.getProperty("net.minecraftforge.gradle.GradleStart.srg.srg-mcp");
+
+            if (Strings.isNullOrEmpty(gradleStartProp))
+            {
+                // get as a resource
+                InputStream classData = getClass().getResourceAsStream(deobfFileName);
+                LZMAInputSupplier zis = new LZMAInputSupplier(classData);
+                CharSource srgSource = zis.asCharSource(Charsets.UTF_8);
+                srgList = srgSource.readLines();
+            }
+            else
+            {
+                srgList = Files.readLines(new File(gradleStartProp), Charsets.UTF_8);
+            }
+
             rawMethodMaps = Maps.newHashMap();
             rawFieldMaps = Maps.newHashMap();
             Builder<String, String> builder = ImmutableBiMap.<String,String>builder();

--- a/src/main/java/net/minecraftforge/fml/common/launcher/FMLDeobfTweaker.java
+++ b/src/main/java/net/minecraftforge/fml/common/launcher/FMLDeobfTweaker.java
@@ -4,6 +4,8 @@ import java.io.File;
 import java.lang.reflect.Method;
 import java.util.List;
 
+import com.google.common.base.Strings;
+
 import net.minecraft.launchwrapper.ITweaker;
 import net.minecraft.launchwrapper.Launch;
 import net.minecraft.launchwrapper.LaunchClassLoader;
@@ -21,7 +23,7 @@ public class FMLDeobfTweaker implements ITweaker {
     public void injectIntoClassLoader(LaunchClassLoader classLoader)
     {
         // Deobfuscation transformer, always last, and the access transformer tweaker as well
-        if (!(Boolean)Launch.blackboard.get("fml.deobfuscatedEnvironment"))
+        if (!(Boolean)Launch.blackboard.get("fml.deobfuscatedEnvironment") || !Strings.isNullOrEmpty(System.getProperty("net.minecraftforge.gradle.GradleStart.srg.srg-mcp")))
         {
             classLoader.registerTransformer("net.minecraftforge.fml.common.asm.transformers.DeobfuscationTransformer");
         }


### PR DESCRIPTION
The version file is no longer necessary at dev time. Neither is the deobfuscationdata.lzma file.
I also take advantage of the GradleStart system properties to enable dev-time deobfuscation of stuff to the current MCP names.
