### PR TITLE
Null check in EventBus when unregistering event handlers

### DIFF
--- a/src/main/java/cpw/mods/fml/common/eventhandler/EventBus.java
+++ b/src/main/java/cpw/mods/fml/common/eventhandler/EventBus.java
@@ -121,9 +121,12 @@ public class EventBus implements IEventExceptionHandler
     public void unregister(Object object)
     {
         ArrayList<IEventListener> list = listeners.remove(object);
-        for (IEventListener listener : list)
+        if (list != null)
         {
-            ListenerList.unregisterAll(busID, listener);
+            for (IEventListener listener : list)
+            {
+                ListenerList.unregisterAll(busID, listener);
+            }
         }
     }
 


### PR DESCRIPTION
There is currently no way to check if an event handler has been registered or not.
But when trying to unregister a not-registered event handler, Minecraft crashes with a NullPointerException.
This is a simple fix to prevent such crashes.

(Same patch applies for 1.8 and newer)
